### PR TITLE
Add retry with backoff and user-friendly scrape errors

### DIFF
--- a/backend/app/routers/scrape.py
+++ b/backend/app/routers/scrape.py
@@ -12,5 +12,7 @@ async def scrape(url: str = Query(..., description="Product URL to scrape")):
         return await scrape_url(url)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=502, detail=f"Failed to scrape: {e}")
+    except ConnectionError as e:
+        raise HTTPException(status_code=502, detail=str(e))
+    except Exception:
+        raise HTTPException(status_code=502, detail="Unexpected error while scraping")

--- a/backend/app/scrapers/madheads.py
+++ b/backend/app/scrapers/madheads.py
@@ -1,3 +1,4 @@
+import asyncio
 import re
 
 import httpx
@@ -123,12 +124,35 @@ class MadHeadsScraper(BaseScraper):
 
         return product
 
+    @staticmethod
+    async def _fetch_with_retry(url: str, retries: int = 3) -> httpx.Response:
+        """Fetch URL with exponential backoff on transient errors."""
+        delays = [1, 3, 9]
+        for attempt in range(retries):
+            try:
+                async with httpx.AsyncClient(follow_redirects=True, timeout=15) as client:
+                    resp = await client.get(url)
+                if resp.status_code == 404:
+                    raise ValueError("Product page not found")
+                resp.raise_for_status()
+                return resp
+            except (httpx.TimeoutException, httpx.ConnectError, httpx.ReadError) as e:
+                if attempt == retries - 1:
+                    if isinstance(e, httpx.TimeoutException):
+                        raise ConnectionError("Roastery site timed out") from e
+                    raise ConnectionError("Could not connect to roastery site") from e
+                await asyncio.sleep(delays[attempt])
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code >= 500 and attempt < retries - 1:
+                    await asyncio.sleep(delays[attempt])
+                    continue
+                raise ValueError(f"Roastery returned error {e.response.status_code}") from e
+        raise ConnectionError("Could not connect to roastery site")
+
     async def scrape(self, url: str) -> ScrapeResult:
         uk_url, en_url = self._normalize_url(url)
 
-        async with httpx.AsyncClient(follow_redirects=True, timeout=15) as client:
-            resp = await client.get(en_url)
-            resp.raise_for_status()
+        resp = await self._fetch_with_retry(en_url)
 
         data = self._extract_data(resp.text)
         chars = data.get("characteristics", {})

--- a/backend/tests/test_retry.py
+++ b/backend/tests/test_retry.py
@@ -1,0 +1,125 @@
+"""Tests for MadHeadsScraper._fetch_with_retry retry/backoff logic."""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from app.scrapers.madheads import MadHeadsScraper
+
+URL = "https://madheadscoffee.com/en/p/test"
+
+
+@pytest.mark.anyio
+async def test_retry_succeeds_after_transient_timeout():
+    """Retries on timeout and succeeds on second attempt."""
+    mock_response = httpx.Response(200, text="ok", request=httpx.Request("GET", URL))
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=[httpx.TimeoutException("timeout"), mock_response])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.scrapers.madheads.httpx.AsyncClient", return_value=mock_client), \
+         patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        resp = await MadHeadsScraper._fetch_with_retry(URL, retries=2)
+
+    assert resp.status_code == 200
+    mock_sleep.assert_called_once_with(1)
+
+
+@pytest.mark.anyio
+async def test_retry_exhausted_on_timeout():
+    """Raises ConnectionError with friendly message after all retries exhausted."""
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.scrapers.madheads.httpx.AsyncClient", return_value=mock_client), \
+         patch("asyncio.sleep", new_callable=AsyncMock):
+        with pytest.raises(ConnectionError, match="Roastery site timed out"):
+            await MadHeadsScraper._fetch_with_retry(URL, retries=2)
+
+
+@pytest.mark.anyio
+async def test_retry_exhausted_on_connect_error():
+    """Raises ConnectionError on connect failure after retries."""
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.scrapers.madheads.httpx.AsyncClient", return_value=mock_client), \
+         patch("asyncio.sleep", new_callable=AsyncMock):
+        with pytest.raises(ConnectionError, match="Could not connect"):
+            await MadHeadsScraper._fetch_with_retry(URL, retries=2)
+
+
+@pytest.mark.anyio
+async def test_no_retry_on_404():
+    """404 is permanent — raises immediately, no retry."""
+    mock_response = httpx.Response(404)
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.scrapers.madheads.httpx.AsyncClient", return_value=mock_client), \
+         patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        with pytest.raises(ValueError, match="Product page not found"):
+            await MadHeadsScraper._fetch_with_retry(URL, retries=3)
+
+    mock_sleep.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_retry_on_500_then_success():
+    """Retries on 500, succeeds on next attempt."""
+    error_response = httpx.Response(500, request=httpx.Request("GET", URL))
+    ok_response = httpx.Response(200, text="ok", request=httpx.Request("GET", URL))
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=[error_response, ok_response])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.scrapers.madheads.httpx.AsyncClient", return_value=mock_client), \
+         patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        resp = await MadHeadsScraper._fetch_with_retry(URL, retries=2)
+
+    assert resp.status_code == 200
+    mock_sleep.assert_called_once_with(1)
+
+
+@pytest.mark.anyio
+async def test_no_retry_on_403():
+    """Non-5xx HTTP errors are permanent — no retry."""
+    error_response = httpx.Response(403, request=httpx.Request("GET", URL))
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=error_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.scrapers.madheads.httpx.AsyncClient", return_value=mock_client), \
+         patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        with pytest.raises(ValueError, match="Roastery returned error 403"):
+            await MadHeadsScraper._fetch_with_retry(URL, retries=3)
+
+    mock_sleep.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_backoff_delays():
+    """Verifies exponential backoff delays (1s, 3s)."""
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.scrapers.madheads.httpx.AsyncClient", return_value=mock_client), \
+         patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        with pytest.raises(ConnectionError):
+            await MadHeadsScraper._fetch_with_retry(URL, retries=3)
+
+    assert mock_sleep.call_args_list == [
+        ((1,),), ((3,),),
+    ]

--- a/backend/tests/test_scrape.py
+++ b/backend/tests/test_scrape.py
@@ -54,7 +54,7 @@ def test_scrape_network_failure(client):
     ):
         resp = client.get("/scrape/", params={"url": "https://madheadscoffee.com/p/test"})
     assert resp.status_code == 502
-    assert "Failed to scrape" in resp.json()["detail"]
+    assert resp.json()["detail"] == "Connection refused"
 
 
 def test_scrape_missing_url_param(client):

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,7 +6,12 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 		...options,
 	});
 	if (!res.ok) {
-		throw new Error(`API error: ${res.status} ${res.statusText}`);
+		let detail = `${res.status} ${res.statusText}`;
+		try {
+			const body = await res.json();
+			if (body.detail) detail = body.detail;
+		} catch { /* no JSON body */ }
+		throw new Error(detail);
 	}
 	if (res.status === 204) return undefined as T;
 	return res.json();

--- a/frontend/src/lib/components/CoffeeDetail.svelte
+++ b/frontend/src/lib/components/CoffeeDetail.svelte
@@ -46,6 +46,7 @@
 	let editDescriptorIds = $state<number[]>([]);
 	let saving = $state(false);
 	let refreshing = $state(false);
+	let refreshError = $state('');
 
 	// Review form
 	let editingReviewTasterId = $state<number | null>(null);
@@ -225,10 +226,13 @@
 	async function refreshCoffee() {
 		if (!coffee?.roastery_url) return;
 		refreshing = true;
+		refreshError = '';
 		try {
 			await api.coffees.refresh(coffeeId);
 			await loadData();
 			onUpdated();
+		} catch (e) {
+			refreshError = e instanceof Error ? e.message : 'Refresh failed';
 		} finally {
 			refreshing = false;
 		}
@@ -549,6 +553,9 @@
 									<span class="text-[10px] text-stone-300">{$t('detail.fetched_at')} {new Date(coffee.fetched_at).toLocaleDateString()}</span>
 								{/if}
 							</div>
+							{#if refreshError}
+								<p class="text-xs text-red-500 mt-1">{refreshError}</p>
+							{/if}
 						{/if}
 						{#if !coffee.roastery_url && coffee.updated_at}
 							<span class="text-[10px] text-stone-300">{$t('detail.updated_at')} {new Date(coffee.updated_at).toLocaleDateString()}</span>

--- a/frontend/src/lib/components/RoasteryDetail.svelte
+++ b/frontend/src/lib/components/RoasteryDetail.svelte
@@ -11,15 +11,19 @@
 	} = $props();
 
 	let refreshing = $state(false);
-	let refreshResult = $state<{ refreshed: number; failed: number } | null>(null);
+	let refreshResult = $state<{ refreshed: number; failed: number; errors: string[] } | null>(null);
+	let refreshError = $state('');
 
 	async function refreshAllCoffees() {
 		refreshing = true;
 		refreshResult = null;
+		refreshError = '';
 		try {
 			const result = await api.roasteries.refresh(roastery.id);
 			refreshResult = result;
 			onUpdated();
+		} catch (e) {
+			refreshError = e instanceof Error ? e.message : 'Refresh failed';
 		} finally {
 			refreshing = false;
 		}
@@ -78,5 +82,15 @@
 				</span>
 			{/if}
 		</div>
+		{#if refreshError}
+			<p class="text-xs text-red-500 mt-2">{refreshError}</p>
+		{/if}
+		{#if refreshResult?.errors?.length}
+			<div class="mt-2 space-y-1">
+				{#each refreshResult.errors as err}
+					<p class="text-xs text-red-400">{err}</p>
+				{/each}
+			</div>
+		{/if}
 	</div>
 </div>


### PR DESCRIPTION
## Summary
- Retry transient errors (timeout, connection, 5xx) with exponential backoff (1s, 3s, 9s)
- No retry on permanent errors (404, 4xx, parse failure)
- User-friendly messages: "Roastery site timed out", "Product page not found", etc.
- Frontend API client reads `detail` field from error responses
- Refresh errors shown inline in CoffeeDetail and RoasteryDetail
- 7 new unit tests for retry logic, total test count: 85 → 92

Closes #9

## Test plan
- [x] All 92 tests pass
- [x] Fake URL shows friendly error in AddCoffeePanel
- [x] Frontend production build passes
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)