### PR TITLE
Rework backup naming — version + migration count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,13 +32,16 @@ release: test
 	@echo "Building release..."
 	rm -rf release/
 	mkdir -p $(RELEASE_DIR)/backend $(RELEASE_DIR)/frontend
-	# Backend: source + deps spec
+	# Backend: source + deps spec + migrations
 	cp -r backend/app $(RELEASE_DIR)/backend/
-	cp backend/pyproject.toml backend/uv.lock $(RELEASE_DIR)/backend/
+	cp -r backend/migrations $(RELEASE_DIR)/backend/
+	cp backend/alembic.ini backend/pyproject.toml backend/uv.lock $(RELEASE_DIR)/backend/
 	# Frontend: build
 	cd frontend && npm run build
 	cp -r frontend/build $(RELEASE_DIR)/frontend/
 	cp frontend/package.json frontend/package-lock.json $(RELEASE_DIR)/frontend/
+	# Deploy scripts
+	cp -r deploy $(RELEASE_DIR)/
 	# Top-level files
 	cp Makefile $(RELEASE_DIR)/
 	# Package
@@ -63,8 +66,4 @@ prod-stop:
 	@echo "Stopped."
 
 prod-backup:
-	@mkdir -p backups
-	$(eval VERSION := $(shell cd backend && uv run python -c "from app import __version__; print(__version__)"))
-	@cp backend/beanbrain.db backups/beanbrain-$(VERSION)-$$(date +%F-%H%M%S).db
-	@echo "Backup: backups/beanbrain-$(VERSION)-$$(date +%F-%H%M%S).db"
-	@find backups/ -name "*.db" -mtime +30 -delete 2>/dev/null; true
+	@deploy/backup-db.sh .


### PR DESCRIPTION
## Summary
- Centralized backup logic in `deploy/backup-db.sh` (gitignored, parameterized)
- Backup filename format: `beanbrain-{version}-m{NNN}-{date}.db`
- Updated `Makefile` prod-backup target to use new script
- Release tarball now includes `migrations/` and `deploy/` directories
- Updated deploy scripts (gitignored): launchd plist, update-backend.sh, deploy.sh

Closes #55

## Manual steps after merge
Deploy scripts are gitignored — apply these changes manually on prod:
1. Copy `deploy/backup-db.sh` to `/Users/services/beanbrain/deploy/`
2. Update launchd plist: `sudo launchctl bootout system/com.beanbrain.backup && sudo launchctl bootstrap system /Library/LaunchDaemons/com.beanbrain.backup.plist`

## Test plan
- [x] `deploy/backup-db.sh .` produces `beanbrain-0.2.0-m001-2026-03-21.db`
- [x] 91 backend tests pass
- [ ] Verify backup on prod after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)