### PR TITLE
Grinder config — range, step, styled display

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -126,6 +126,9 @@ class Grinder(Base):
     model = Column(String, nullable=True)
     kind = Column(String, default="auto")  # "auto" or "manual"
     is_default = Column(Boolean, default=False)
+    range_min = Column(Float, default=0)
+    range_max = Column(Float, nullable=True)  # null = no upper bound
+    step = Column(Float, default=1)
 
     grinder_settings = relationship("GrinderSetting", back_populates="grinder")
 

--- a/backend/app/routers/coffees.py
+++ b/backend/app/routers/coffees.py
@@ -107,6 +107,8 @@ def list_coffees(
         data.avg_rating = round(avg, 1) if avg else None
         data.person_rating = person_ratings.get(c.id)
         data.default_grind = default_grinds.get(c.id)
+        if default_grinder:
+            data.default_grind_step = default_grinder.step or 1
         result.append(data)
     return result
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -71,6 +71,9 @@ class GrinderCreate(BaseModel):
     model: str | None = None
     kind: Literal["auto", "manual"] = "auto"
     is_default: bool = False
+    range_min: float = 0
+    range_max: float | None = None
+    step: float = 1
 
 
 class GrinderUpdate(BaseModel):
@@ -78,6 +81,9 @@ class GrinderUpdate(BaseModel):
     model: str | None = None
     kind: Literal["auto", "manual"] | None = None
     is_default: bool | None = None
+    range_min: float | None = None
+    range_max: float | None = None
+    step: float | None = None
 
 
 class GrinderOut(BaseModel):
@@ -86,6 +92,9 @@ class GrinderOut(BaseModel):
     model: str | None = None
     kind: str
     is_default: bool
+    range_min: float
+    range_max: float | None = None
+    step: float
 
     model_config = {"from_attributes": True}
 
@@ -259,6 +268,7 @@ class CoffeeListOut(BaseModel):
     avg_rating: float | None = None
     person_rating: int | None = None
     default_grind: float | None = None
+    default_grind_step: float = 1
     roastery_descriptors: list[DescriptorOut] = []
 
     model_config = {"from_attributes": True}

--- a/backend/migrations/versions/5708f4e75ba9_add_grinder_range_and_step.py
+++ b/backend/migrations/versions/5708f4e75ba9_add_grinder_range_and_step.py
@@ -1,0 +1,34 @@
+"""add grinder range and step
+
+Revision ID: 5708f4e75ba9
+Revises: 3817fe24fdf7
+Create Date: 2026-03-21 16:24:10.779592
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '5708f4e75ba9'
+down_revision: Union[str, Sequence[str], None] = '3817fe24fdf7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add range_min, range_max, step columns to grinders."""
+    with op.batch_alter_table('grinders', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('range_min', sa.Float(), server_default='0'))
+        batch_op.add_column(sa.Column('range_max', sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column('step', sa.Float(), server_default='1'))
+
+
+def downgrade() -> None:
+    """Remove range_min, range_max, step columns from grinders."""
+    with op.batch_alter_table('grinders', schema=None) as batch_op:
+        batch_op.drop_column('step')
+        batch_op.drop_column('range_max')
+        batch_op.drop_column('range_min')

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -34,6 +34,9 @@ export interface Grinder {
 	model: string | null;
 	kind: string;
 	is_default: boolean;
+	range_min: number;
+	range_max: number | null;
+	step: number;
 }
 
 export interface BrewSetup {
@@ -132,6 +135,7 @@ export interface CoffeeListItem {
 	avg_rating: number | null;
 	person_rating: number | null;
 	default_grind: number | null;
+	default_grind_step: number;
 	created_at: string;
 	roastery_descriptors: Descriptor[];
 }
@@ -235,7 +239,7 @@ export const api = {
 	},
 	grinders: {
 		list: () => request<Grinder[]>('/grinders/'),
-		create: (data: { name: string; model?: string; kind?: string; is_default?: boolean }) =>
+		create: (data: { name: string; model?: string; kind?: string; is_default?: boolean; range_min?: number; range_max?: number | null; step?: number }) =>
 			request<Grinder>('/grinders/', { method: 'POST', body: JSON.stringify(data) }),
 		update: (id: number, data: Record<string, unknown>) =>
 			request<Grinder>(`/grinders/${id}`, { method: 'PUT', body: JSON.stringify(data) }),

--- a/frontend/src/lib/components/AddGrinderPanel.svelte
+++ b/frontend/src/lib/components/AddGrinderPanel.svelte
@@ -11,6 +11,9 @@
 	let name = $state('');
 	let model = $state('');
 	let kind = $state<'auto' | 'manual'>('auto');
+	let rangeMin = $state<number | string>(0);
+	let rangeMax = $state<number | string>('');
+	let step = $state<number | string>(1);
 	let saving = $state(false);
 
 	async function save() {
@@ -20,6 +23,9 @@
 			name: name.trim(),
 			model: model.trim() || undefined,
 			kind,
+			range_min: Number(rangeMin) || 0,
+			range_max: rangeMax !== '' ? Number(rangeMax) : null,
+			step: Number(step) || 1,
 		});
 		saving = false;
 		onCreated(grinder.id);
@@ -65,6 +71,22 @@
 			<input id="grinder-model" type="text" bind:value={model} placeholder={$t('grinding.model_placeholder')}
 				class="w-full mt-1 px-4 py-2.5 rounded-lg border border-stone-200 text-base bg-card-inset
 					focus:outline-none focus:ring-2 focus:ring-amber-400/50 focus:border-amber-300" />
+		</div>
+		<div>
+			<label class="text-xs text-stone-400 uppercase tracking-wide">{$t('grinding.range')}</label>
+			<div class="flex items-center gap-2 mt-1">
+				<input type="number" bind:value={rangeMin} placeholder="0"
+					class="w-24 px-3 py-2.5 rounded-lg border border-stone-200 text-base bg-card-inset text-center
+						focus:outline-none focus:ring-2 focus:ring-amber-400/50" />
+				<span class="text-stone-400">—</span>
+				<input type="number" bind:value={rangeMax} placeholder="∞"
+					class="w-24 px-3 py-2.5 rounded-lg border border-stone-200 text-base bg-card-inset text-center
+						focus:outline-none focus:ring-2 focus:ring-amber-400/50" />
+				<span class="text-xs text-stone-400 mx-1">{$t('grinding.step')}</span>
+				<input type="number" bind:value={step} placeholder="1" min="0.1" step="0.1"
+					class="w-20 px-3 py-2.5 rounded-lg border border-stone-200 text-base bg-card-inset text-center
+						focus:outline-none focus:ring-2 focus:ring-amber-400/50" />
+			</div>
 		</div>
 		<div class="flex gap-2 pt-2">
 			<button onclick={save} disabled={!name.trim() || saving}

--- a/frontend/src/lib/components/CoffeeDetail.svelte
+++ b/frontend/src/lib/components/CoffeeDetail.svelte
@@ -7,6 +7,7 @@
 	import StarRating from './StarRating.svelte';
 	import DescriptorAutocomplete from './DescriptorAutocomplete.svelte';
 	import ReviewForm from './ReviewForm.svelte';
+	import GrindValue from './GrindValue.svelte';
 	import Icons from './Icons.svelte';
 
 	let currentLang = $state('en');
@@ -586,7 +587,7 @@
 				{/if}
 				{#each coffee.grinder_settings as setting}
 					<div class="flex flex-wrap items-center gap-2 md:gap-3 py-2 border-b border-stone-50 last:border-0">
-						<span class="text-2xl md:text-3xl font-bold text-amber-700 tabular-nums flex-shrink-0">{setting.setting}</span>
+						<GrindValue value={setting.setting} step={setting.grinder.step} class="text-2xl md:text-3xl text-amber-700 flex-shrink-0" />
 						<div class="flex flex-wrap gap-2 flex-1 min-w-0">
 							<div class="flex items-center gap-1.5 md:gap-2 px-2 md:px-3 py-1.5 bg-card-inset rounded-lg">
 								<img src="/img/grinder-{setting.grinder.kind === 'manual' ? 'manual' : 'auto'}.png" alt="" class="w-4 h-4 md:w-5 md:h-5 opacity-50" />
@@ -611,7 +612,12 @@
 						<!-- Grind value — big centered input -->
 						<div class="flex items-center justify-center gap-3">
 							<img src="/img/burr-icon.png" alt="" class="w-8 h-8 opacity-40" />
-							<input type="number" step="0.5" bind:value={settingValue} placeholder="12.5"
+							<input type="number"
+								step={selectedGrinder?.step ?? 1}
+								min={selectedGrinder?.range_min ?? 0}
+								max={selectedGrinder?.range_max ?? undefined}
+								bind:value={settingValue}
+								placeholder={selectedGrinder && selectedGrinder.step % 1 !== 0 ? '12.5' : '12'}
 								class="w-24 px-3 py-2 rounded-xl border border-stone-200 text-2xl font-bold text-amber-700 text-center bg-card
 									focus:outline-none focus:ring-2 focus:ring-amber-400/50 tabular-nums" />
 						</div>

--- a/frontend/src/lib/components/CoffeeSidebar.svelte
+++ b/frontend/src/lib/components/CoffeeSidebar.svelte
@@ -5,6 +5,7 @@
 	import { t } from '$lib/i18n';
 	import { lang } from '$lib/lang';
 	import SidebarShell from './SidebarShell.svelte';
+	import GrindValue from './GrindValue.svelte';
 	import Icons from './Icons.svelte';
 
 	let currentLang = $state('en');
@@ -384,15 +385,15 @@
 							{@const rating = coffee.person_rating ?? coffee.avg_rating}
 							<div class="flex-shrink-0 ml-3 space-y-1">
 								{#if rating != null}
-									<div class="flex items-center justify-end" title="Rating">
+									<div class="flex items-center justify-end gap-1" title="Rating">
 										<img src="/img/icon-rating.png" alt="" class="w-8 h-8 {coffee.person_rating != null ? 'opacity-70' : 'opacity-30'}" />
-										<span class="w-10 text-right text-2xl tabular-nums font-bold {coffee.person_rating != null ? 'text-amber-700' : 'text-stone-400'}">{Math.round(rating * 10) / 10}</span>
+										<span class="w-12 text-right text-2xl tabular-nums font-bold {coffee.person_rating != null ? 'text-amber-700' : 'text-stone-400'}">{Math.round(rating * 10) / 10}</span>
 									</div>
 								{/if}
 								{#if coffee.default_grind != null}
-									<div class="flex items-center justify-end" title="Grind setting">
+									<div class="flex items-center justify-end gap-1" title="Grind setting">
 										<img src="/img/icon-grind.png" alt="" class="w-8 h-8 opacity-50" />
-										<span class="w-10 text-right text-2xl text-amber-700 tabular-nums font-bold">{coffee.default_grind}</span>
+										<span class="w-12 text-right"><GrindValue value={coffee.default_grind} step={coffee.default_grind_step} class="text-2xl text-amber-700" /></span>
 									</div>
 								{/if}
 							</div>

--- a/frontend/src/lib/components/GrindValue.svelte
+++ b/frontend/src/lib/components/GrindValue.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	interface Props {
+		value: number;
+		step?: number;
+		class?: string;
+	}
+
+	let { value, step = 1, class: className = '' }: Props = $props();
+
+	const isWholeStep = $derived(step % 1 === 0);
+	const intPart = $derived(Math.floor(value));
+	const decPart = $derived(isWholeStep ? '' : '.' + (value % 1 === 0 ? '0' : String(Math.round((value % 1) * 10))));
+</script>
+
+<span class="tabular-nums font-bold {className}">
+	{intPart}{#if decPart}<span class="text-[0.6em] opacity-70">{decPart}</span>{/if}
+</span>

--- a/frontend/src/lib/components/GrinderDetail.svelte
+++ b/frontend/src/lib/components/GrinderDetail.svelte
@@ -20,6 +20,24 @@
 		onUpdated();
 	}
 
+	let editRangeMin = $state(0);
+	let editRangeMax = $state<number | string>('');
+	let editStep = $state(1);
+	$effect(() => {
+		editRangeMin = grinder.range_min;
+		editRangeMax = grinder.range_max ?? '';
+		editStep = grinder.step;
+	});
+
+	async function saveRange() {
+		await api.grinders.update(grinder.id, {
+			range_min: Number(editRangeMin) || 0,
+			range_max: editRangeMax !== '' ? Number(editRangeMax) : null,
+			step: Number(editStep) || 1,
+		});
+		onUpdated();
+	}
+
 	async function deleteGrinder() {
 		if (!confirm(`Delete "${grinder.name}"?`)) return;
 		await api.grinders.delete(grinder.id);
@@ -81,6 +99,27 @@
 						{grinder.kind === 'manual' ? 'translate-x-7' : 'translate-x-1'}"></span>
 				</button>
 				<span class="text-sm text-stone-500">{grinder.kind === 'manual' ? 'Manual' : 'Auto'}</span>
+			</div>
+		</div>
+
+		<div class="border-t border-stone-100 pt-4">
+			<label class="text-xs text-stone-400 uppercase tracking-wide">{$t('grinding.range')}</label>
+			<div class="flex items-center gap-2 mt-2">
+				<input type="number" bind:value={editRangeMin} placeholder="0"
+					class="w-24 px-3 py-2 rounded-lg border border-stone-200 text-base bg-card-inset text-center
+						focus:outline-none focus:ring-2 focus:ring-amber-400/50" />
+				<span class="text-stone-400">—</span>
+				<input type="number" bind:value={editRangeMax} placeholder="∞"
+					class="w-24 px-3 py-2 rounded-lg border border-stone-200 text-base bg-card-inset text-center
+						focus:outline-none focus:ring-2 focus:ring-amber-400/50" />
+				<span class="text-xs text-stone-400 mx-1">{$t('grinding.step')}</span>
+				<input type="number" bind:value={editStep} placeholder="1" min="0.1" step="0.1"
+					class="w-20 px-3 py-2 rounded-lg border border-stone-200 text-base bg-card-inset text-center
+						focus:outline-none focus:ring-2 focus:ring-amber-400/50" />
+				<button onclick={saveRange}
+					class="ml-2 px-4 py-2 bg-amber-700 text-white rounded-lg text-sm hover:bg-amber-800">
+					{$t('common.save')}
+				</button>
 			</div>
 		</div>
 	</div>

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -113,6 +113,8 @@ const translations: Record<string, Record<string, string>> = {
 	'grinding.name_placeholder': { en: 'e.g. Eureka Mignon', uk: 'напр. Eureka Mignon' },
 	'grinding.model': { en: 'Model', uk: 'Модель' },
 	'grinding.model_placeholder': { en: 'Model (optional)', uk: 'Модель (необов.)' },
+	'grinding.range': { en: 'Range', uk: 'Діапазон' },
+	'grinding.step': { en: 'Step', uk: 'Крок' },
 	'grinding.select': { en: 'Select a grinder', uk: 'Оберіть кавомолку' },
 
 	// Brewing tab (sidebar + detail)

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -98,6 +98,7 @@
 
 	async function onGrinderUpdated() {
 		await loadGrinders();
+		await loadCoffees();
 		// Re-select to refresh detail
 		if (grinderPanel.type === 'detail') {
 			grinderPanel = { ...grinderPanel };
@@ -125,6 +126,7 @@
 
 	async function onBrewSetupUpdated() {
 		await loadBrewSetups();
+		await loadCoffees();
 		if (brewPanel.type === 'detail') {
 			brewPanel = { ...brewPanel };
 		}


### PR DESCRIPTION
## Summary
- Add `range_min`, `range_max`, `step` columns to Grinder model (Alembic migration)
- Grinder setting input dynamically uses grinder's min/max/step (was hardcoded `step="0.5"`)
- New `GrindValue` component: integer part in normal size, decimal part (`.5`) in smaller font
- Styled grind display in both sidebar and detail panel
- Range/step fields in grinder create and edit forms
- EN/UA translations for new labels

Closes #6

## Test plan
- [x] 91 backend tests pass, ruff clean
- [x] svelte-check: 0 errors
- [ ] Set DF54 grinder step to 0.5, verify sidebar shows `16` big + `.5` small
- [ ] Set 1Zpresso step to 1, verify whole numbers show without decimal
- [ ] Verify grinder input respects min/max/step constraints

🤖 Generated with [Claude Code](https://claude.com/claude-code)