### PR TITLE
Per-brew-method reviews

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -102,12 +102,13 @@ class Taster(Base):
 class Review(Base):
     __tablename__ = "reviews"
     __table_args__ = (
-        UniqueConstraint("coffee_id", "taster_id", name="uq_review_coffee_taster"),
+        UniqueConstraint("coffee_id", "taster_id", "brew_setup_id", name="uq_review_coffee_taster_setup"),
     )
 
     id = Column(Integer, primary_key=True, index=True)
     coffee_id = Column(Integer, ForeignKey("coffees.id", ondelete="CASCADE"), nullable=False)
     taster_id = Column(Integer, ForeignKey("tasters.id"), nullable=False)
+    brew_setup_id = Column(Integer, ForeignKey("brew_setups.id"), nullable=False)
     rating = Column(Integer, nullable=False)  # 1-10 (displayed as 5 stars with halves)
     comment = Column(String, nullable=True)
     updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc),
@@ -115,6 +116,7 @@ class Review(Base):
 
     coffee = relationship("Coffee", back_populates="reviews")
     taster = relationship("Taster")
+    brew_setup = relationship("BrewSetup")
     descriptors = relationship("Descriptor", secondary=review_descriptor)
 
 

--- a/backend/app/routers/coffees.py
+++ b/backend/app/routers/coffees.py
@@ -79,19 +79,25 @@ def list_coffees(
         .all()
     )
 
-    # Bulk: person ratings (1 query)
+    # Shared: default equipment (used for person_rating + default_grind)
+    default_grinder = db.query(Grinder).filter(Grinder.is_default.is_(True)).first()
+    default_setup = db.query(BrewSetup).filter(BrewSetup.is_default.is_(True)).first()
+
+    # Bulk: person ratings for default brew setup (1 query)
     person_ratings = {}
-    if taster_id:
+    if taster_id and default_setup:
         person_ratings = dict(
             db.query(Review.coffee_id, Review.rating)
-            .filter(Review.coffee_id.in_(coffee_ids), Review.taster_id == taster_id)
+            .filter(
+                Review.coffee_id.in_(coffee_ids),
+                Review.taster_id == taster_id,
+                Review.brew_setup_id == default_setup.id,
+            )
             .all()
         )
 
     # Bulk: default grind settings (1+2 queries instead of 3N)
     default_grinds: dict[int, float] = {}
-    default_grinder = db.query(Grinder).filter(Grinder.is_default.is_(True)).first()
-    default_setup = db.query(BrewSetup).filter(BrewSetup.is_default.is_(True)).first()
     if default_grinder and default_setup:
         for row in db.query(GrinderSetting.coffee_id, GrinderSetting.setting).filter(
             GrinderSetting.coffee_id.in_(coffee_ids),
@@ -123,6 +129,7 @@ def get_coffee(coffee_id: int, db: Session = Depends(get_db)):
             joinedload(Coffee.roastery_descriptors),
             joinedload(Coffee.reviews).joinedload(Review.descriptors),
             joinedload(Coffee.reviews).joinedload(Review.taster),
+            joinedload(Coffee.reviews).joinedload(Review.brew_setup),
             joinedload(Coffee.grinder_settings).joinedload(GrinderSetting.grinder),
             joinedload(Coffee.grinder_settings).joinedload(GrinderSetting.brew_setup),
         )
@@ -204,6 +211,7 @@ async def refresh_coffee(coffee_id: int, db: Session = Depends(get_db)):
             joinedload(Coffee.roastery_descriptors),
             joinedload(Coffee.reviews).joinedload(Review.descriptors),
             joinedload(Coffee.reviews).joinedload(Review.taster),
+            joinedload(Coffee.reviews).joinedload(Review.brew_setup),
             joinedload(Coffee.grinder_settings).joinedload(GrinderSetting.grinder),
             joinedload(Coffee.grinder_settings).joinedload(GrinderSetting.brew_setup),
         )

--- a/backend/app/routers/reviews.py
+++ b/backend/app/routers/reviews.py
@@ -16,7 +16,7 @@ def list_reviews(coffee_id: int, db: Session = Depends(get_db)):
 
     return (
         db.query(Review)
-        .options(joinedload(Review.descriptors), joinedload(Review.taster))
+        .options(joinedload(Review.descriptors), joinedload(Review.taster), joinedload(Review.brew_setup))
         .filter(Review.coffee_id == coffee_id)
         .all()
     )
@@ -24,14 +24,18 @@ def list_reviews(coffee_id: int, db: Session = Depends(get_db)):
 
 @router.put("/", response_model=ReviewOut)
 def upsert_review(coffee_id: int, data: ReviewUpsert, db: Session = Depends(get_db)):
-    """Create or update a review. One review per person per coffee."""
+    """Create or update a review. One review per person per coffee per brew setup."""
     coffee = db.query(Coffee).filter(Coffee.id == coffee_id).first()
     if not coffee:
         raise HTTPException(status_code=404, detail="Coffee not found")
 
     review = (
         db.query(Review)
-        .filter(Review.coffee_id == coffee_id, Review.taster_id == data.taster_id)
+        .filter(
+            Review.coffee_id == coffee_id,
+            Review.taster_id == data.taster_id,
+            Review.brew_setup_id == data.brew_setup_id,
+        )
         .first()
     )
 
@@ -42,6 +46,7 @@ def upsert_review(coffee_id: int, data: ReviewUpsert, db: Session = Depends(get_
         review = Review(
             coffee_id=coffee_id,
             taster_id=data.taster_id,
+            brew_setup_id=data.brew_setup_id,
             rating=data.rating,
             comment=data.comment,
         )
@@ -60,7 +65,7 @@ def upsert_review(coffee_id: int, data: ReviewUpsert, db: Session = Depends(get_
 
     return (
         db.query(Review)
-        .options(joinedload(Review.descriptors), joinedload(Review.taster))
+        .options(joinedload(Review.descriptors), joinedload(Review.taster), joinedload(Review.brew_setup))
         .filter(Review.id == review.id)
         .first()
     )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -161,6 +161,7 @@ class GrinderSettingOut(BaseModel):
 
 class ReviewUpsert(BaseModel):
     taster_id: int
+    brew_setup_id: int
     rating: int = Field(ge=1, le=10)
     comment: str | None = None
     descriptor_ids: list[int] = []
@@ -170,7 +171,9 @@ class ReviewOut(BaseModel):
     id: int
     coffee_id: int
     taster_id: int
+    brew_setup_id: int
     taster: TasterOut
+    brew_setup: BrewSetupOut
     rating: int
     comment: str | None = None
     updated_at: datetime

--- a/backend/migrations/versions/b597de861e84_add_brew_setup_id_to_reviews.py
+++ b/backend/migrations/versions/b597de861e84_add_brew_setup_id_to_reviews.py
@@ -1,0 +1,65 @@
+"""add brew_setup_id to reviews
+
+Revision ID: b597de861e84
+Revises: 5f94067f351a
+Create Date: 2026-03-21 18:45:19.318968
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b597de861e84'
+down_revision: Union[str, Sequence[str], None] = '5f94067f351a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add brew_setup_id to reviews, backfill with default brew setup."""
+    # 1. Add column as nullable first
+    with op.batch_alter_table('reviews', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('brew_setup_id', sa.Integer(), nullable=True))
+
+    # 2. Backfill: assign all existing reviews to the default brew setup
+    conn = op.get_bind()
+    default_setup = conn.execute(
+        sa.text("SELECT id FROM brew_setups WHERE is_default = 1 LIMIT 1")
+    ).scalar()
+
+    if default_setup is None:
+        # Fallback: use the first brew setup
+        default_setup = conn.execute(
+            sa.text("SELECT id FROM brew_setups ORDER BY id LIMIT 1")
+        ).scalar()
+
+    if default_setup is not None:
+        conn.execute(
+            sa.text("UPDATE reviews SET brew_setup_id = :sid WHERE brew_setup_id IS NULL"),
+            {"sid": default_setup},
+        )
+
+    # 3. Recreate table with NOT NULL constraint, FK, and new unique constraint
+    with op.batch_alter_table('reviews', schema=None) as batch_op:
+        batch_op.alter_column('brew_setup_id', nullable=False)
+        batch_op.create_foreign_key(
+            'fk_review_brew_setup', 'brew_setups', ['brew_setup_id'], ['id']
+        )
+        batch_op.drop_constraint('uq_review_coffee_taster', type_='unique')
+        batch_op.create_unique_constraint(
+            'uq_review_coffee_taster_setup', ['coffee_id', 'taster_id', 'brew_setup_id']
+        )
+
+
+def downgrade() -> None:
+    """Remove brew_setup_id from reviews, restore old unique constraint."""
+    with op.batch_alter_table('reviews', schema=None) as batch_op:
+        batch_op.drop_constraint('uq_review_coffee_taster_setup', type_='unique')
+        batch_op.drop_constraint('fk_review_brew_setup', type_='foreignkey')
+        batch_op.drop_column('brew_setup_id')
+        batch_op.create_unique_constraint(
+            'uq_review_coffee_taster', ['coffee_id', 'taster_id']
+        )

--- a/backend/tests/test_coffee_list.py
+++ b/backend/tests/test_coffee_list.py
@@ -2,16 +2,17 @@
 
 
 def _setup(client):
-    """Create a roastery + coffee, return (roastery_id, coffee_id)."""
+    """Create a roastery + coffee, return (roastery_id, coffee_id, default_setup_id)."""
     rid = client.post("/roasteries/", json={"name": "Test Roastery"}).json()["id"]
     cid = client.post("/coffees/", json={"name": "Test Coffee", "roastery_id": rid}).json()["id"]
-    return rid, cid
+    sid = next(s["id"] for s in client.get("/brew-setups/").json() if s["is_default"])
+    return rid, cid, sid
 
 
 def test_avg_rating_single_review(client):
-    _, cid = _setup(client)
+    _, cid, sid = _setup(client)
     tid = client.post("/tasters/", json={"name": "Alex"}).json()["id"]
-    client.put(f"/coffees/{cid}/reviews/", json={"taster_id": tid, "rating": 8})
+    client.put(f"/coffees/{cid}/reviews/", json={"taster_id": tid, "brew_setup_id": sid, "rating": 8})
 
     coffees = client.get("/coffees/").json()
     coffee = next(c for c in coffees if c["id"] == cid)
@@ -19,11 +20,11 @@ def test_avg_rating_single_review(client):
 
 
 def test_avg_rating_multiple_reviews(client):
-    _, cid = _setup(client)
+    _, cid, sid = _setup(client)
     t1 = client.post("/tasters/", json={"name": "Alex"}).json()["id"]
     t2 = client.post("/tasters/", json={"name": "Kate"}).json()["id"]
-    client.put(f"/coffees/{cid}/reviews/", json={"taster_id": t1, "rating": 7})
-    client.put(f"/coffees/{cid}/reviews/", json={"taster_id": t2, "rating": 9})
+    client.put(f"/coffees/{cid}/reviews/", json={"taster_id": t1, "brew_setup_id": sid, "rating": 7})
+    client.put(f"/coffees/{cid}/reviews/", json={"taster_id": t2, "brew_setup_id": sid, "rating": 9})
 
     coffees = client.get("/coffees/").json()
     coffee = next(c for c in coffees if c["id"] == cid)
@@ -31,13 +32,13 @@ def test_avg_rating_multiple_reviews(client):
 
 
 def test_avg_rating_rounds_to_one_decimal(client):
-    _, cid = _setup(client)
+    _, cid, sid = _setup(client)
     t1 = client.post("/tasters/", json={"name": "Alex"}).json()["id"]
     t2 = client.post("/tasters/", json={"name": "Kate"}).json()["id"]
     t3 = client.post("/tasters/", json={"name": "Sam"}).json()["id"]
-    client.put(f"/coffees/{cid}/reviews/", json={"taster_id": t1, "rating": 7})
-    client.put(f"/coffees/{cid}/reviews/", json={"taster_id": t2, "rating": 8})
-    client.put(f"/coffees/{cid}/reviews/", json={"taster_id": t3, "rating": 9})
+    client.put(f"/coffees/{cid}/reviews/", json={"taster_id": t1, "brew_setup_id": sid, "rating": 7})
+    client.put(f"/coffees/{cid}/reviews/", json={"taster_id": t2, "brew_setup_id": sid, "rating": 8})
+    client.put(f"/coffees/{cid}/reviews/", json={"taster_id": t3, "brew_setup_id": sid, "rating": 9})
 
     coffees = client.get("/coffees/").json()
     coffee = next(c for c in coffees if c["id"] == cid)
@@ -45,18 +46,18 @@ def test_avg_rating_rounds_to_one_decimal(client):
 
 
 def test_avg_rating_none_without_reviews(client):
-    _, cid = _setup(client)
+    _, cid, sid = _setup(client)
     coffees = client.get("/coffees/").json()
     coffee = next(c for c in coffees if c["id"] == cid)
     assert coffee["avg_rating"] is None
 
 
 def test_person_rating(client):
-    _, cid = _setup(client)
+    _, cid, sid = _setup(client)
     t1 = client.post("/tasters/", json={"name": "Alex"}).json()["id"]
     t2 = client.post("/tasters/", json={"name": "Kate"}).json()["id"]
-    client.put(f"/coffees/{cid}/reviews/", json={"taster_id": t1, "rating": 7})
-    client.put(f"/coffees/{cid}/reviews/", json={"taster_id": t2, "rating": 9})
+    client.put(f"/coffees/{cid}/reviews/", json={"taster_id": t1, "brew_setup_id": sid, "rating": 7})
+    client.put(f"/coffees/{cid}/reviews/", json={"taster_id": t2, "brew_setup_id": sid, "rating": 9})
 
     coffees = client.get("/coffees/", params={"taster_id": t1}).json()
     coffee = next(c for c in coffees if c["id"] == cid)
@@ -64,7 +65,7 @@ def test_person_rating(client):
 
 
 def test_person_rating_none_without_review(client):
-    _, cid = _setup(client)
+    _, cid, sid = _setup(client)
     t1 = client.post("/tasters/", json={"name": "Alex"}).json()["id"]
 
     coffees = client.get("/coffees/", params={"taster_id": t1}).json()
@@ -73,7 +74,7 @@ def test_person_rating_none_without_review(client):
 
 
 def test_default_grind(client):
-    _, cid = _setup(client)
+    _, cid, sid = _setup(client)
     grinder_id = next(g["id"] for g in client.get("/grinders/").json() if g["is_default"])
     setup_id = next(s["id"] for s in client.get("/brew-setups/").json() if s["is_default"])
 
@@ -89,7 +90,7 @@ def test_default_grind(client):
 
 
 def test_default_grind_none_without_setting(client):
-    _, cid = _setup(client)
+    _, cid, sid = _setup(client)
     coffees = client.get("/coffees/").json()
     coffee = next(c for c in coffees if c["id"] == cid)
     assert coffee["default_grind"] is None

--- a/backend/tests/test_reviews.py
+++ b/backend/tests/test_reviews.py
@@ -9,12 +9,19 @@ def _create_taster(client, name="Alex"):
     return resp.json()["id"]
 
 
+def _default_brew_setup_id(client):
+    setups = client.get("/brew-setups/").json()
+    return next(s["id"] for s in setups if s["is_default"])
+
+
 def test_create_review(client):
     coffee_id = _create_coffee(client)
     taster_id = _create_taster(client)
+    setup_id = _default_brew_setup_id(client)
 
     resp = client.put(f"/coffees/{coffee_id}/reviews/", json={
         "taster_id": taster_id,
+        "brew_setup_id": setup_id,
         "rating": 8,
         "comment": "Very smooth, great crema",
     })
@@ -22,18 +29,20 @@ def test_create_review(client):
     data = resp.json()
     assert data["taster"]["name"] == "Alex"
     assert data["rating"] == 8
+    assert data["brew_setup_id"] == setup_id
 
 
 def test_upsert_review(client):
-    """Same person updating their review should overwrite, not create new."""
+    """Same person + brew setup updating their review should overwrite, not create new."""
     coffee_id = _create_coffee(client)
     taster_id = _create_taster(client)
+    setup_id = _default_brew_setup_id(client)
 
     client.put(f"/coffees/{coffee_id}/reviews/", json={
-        "taster_id": taster_id, "rating": 6, "comment": "Ok",
+        "taster_id": taster_id, "brew_setup_id": setup_id, "rating": 6, "comment": "Ok",
     })
     resp = client.put(f"/coffees/{coffee_id}/reviews/", json={
-        "taster_id": taster_id, "rating": 9, "comment": "Actually great!",
+        "taster_id": taster_id, "brew_setup_id": setup_id, "rating": 9, "comment": "Actually great!",
     })
     assert resp.json()["rating"] == 9
     assert resp.json()["comment"] == "Actually great!"
@@ -46,11 +55,13 @@ def test_upsert_review(client):
 def test_review_with_descriptors(client):
     coffee_id = _create_coffee(client)
     taster_id = _create_taster(client, "Kate")
+    setup_id = _default_brew_setup_id(client)
     descriptors = client.get("/descriptors").json()
     chocolate_id = next(d["id"] for d in descriptors if d["name"] == "Chocolate")
 
     resp = client.put(f"/coffees/{coffee_id}/reviews/", json={
         "taster_id": taster_id,
+        "brew_setup_id": setup_id,
         "rating": 7,
         "descriptor_ids": [chocolate_id],
     })
@@ -61,24 +72,53 @@ def test_review_with_descriptors(client):
 def test_review_rating_validation(client):
     coffee_id = _create_coffee(client)
     taster_id = _create_taster(client)
+    setup_id = _default_brew_setup_id(client)
 
     resp = client.put(f"/coffees/{coffee_id}/reviews/", json={
-        "taster_id": taster_id, "rating": 0,
+        "taster_id": taster_id, "brew_setup_id": setup_id, "rating": 0,
     })
     assert resp.status_code == 422
 
     resp = client.put(f"/coffees/{coffee_id}/reviews/", json={
-        "taster_id": taster_id, "rating": 11,
+        "taster_id": taster_id, "brew_setup_id": setup_id, "rating": 11,
     })
     assert resp.status_code == 422
+
+
+def test_per_method_reviews(client):
+    """Same person can review same coffee for different brew methods."""
+    coffee_id = _create_coffee(client)
+    taster_id = _create_taster(client)
+
+    # Create a second brew setup
+    s2 = client.post("/brew-setups/", json={
+        "method_type": "pourover", "manufacturer": "Hario", "model": "V60",
+    }).json()
+
+    setup1 = _default_brew_setup_id(client)
+    setup2 = s2["id"]
+
+    client.put(f"/coffees/{coffee_id}/reviews/", json={
+        "taster_id": taster_id, "brew_setup_id": setup1, "rating": 9,
+    })
+    client.put(f"/coffees/{coffee_id}/reviews/", json={
+        "taster_id": taster_id, "brew_setup_id": setup2, "rating": 5,
+    })
+
+    reviews = client.get(f"/coffees/{coffee_id}/reviews/").json()
+    assert len(reviews) == 2
+    ratings = {r["brew_setup_id"]: r["rating"] for r in reviews}
+    assert ratings[setup1] == 9
+    assert ratings[setup2] == 5
 
 
 def test_list_reviews(client):
     coffee_id = _create_coffee(client)
     t1 = _create_taster(client, "Alex")
     t2 = _create_taster(client, "Kate")
-    client.put(f"/coffees/{coffee_id}/reviews/", json={"taster_id": t1, "rating": 8})
-    client.put(f"/coffees/{coffee_id}/reviews/", json={"taster_id": t2, "rating": 6})
+    setup_id = _default_brew_setup_id(client)
+    client.put(f"/coffees/{coffee_id}/reviews/", json={"taster_id": t1, "brew_setup_id": setup_id, "rating": 8})
+    client.put(f"/coffees/{coffee_id}/reviews/", json={"taster_id": t2, "brew_setup_id": setup_id, "rating": 6})
 
     resp = client.get(f"/coffees/{coffee_id}/reviews/")
     assert resp.status_code == 200
@@ -88,8 +128,9 @@ def test_list_reviews(client):
 def test_delete_review(client):
     coffee_id = _create_coffee(client)
     taster_id = _create_taster(client)
+    setup_id = _default_brew_setup_id(client)
     create = client.put(f"/coffees/{coffee_id}/reviews/", json={
-        "taster_id": taster_id, "rating": 5,
+        "taster_id": taster_id, "brew_setup_id": setup_id, "rating": 5,
     })
     review_id = create.json()["id"]
 
@@ -102,8 +143,9 @@ def test_delete_review(client):
 
 def test_review_for_nonexistent_coffee(client):
     taster_id = _create_taster(client)
+    setup_id = _default_brew_setup_id(client)
     resp = client.put("/coffees/999/reviews/", json={
-        "taster_id": taster_id, "rating": 5,
+        "taster_id": taster_id, "brew_setup_id": setup_id, "rating": 5,
     })
     assert resp.status_code == 404
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -49,7 +49,7 @@ wheels = [
 
 [[package]]
 name = "beanbrain"
-version = "0.3.1"
+version = "0.3.2"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -69,7 +69,9 @@ export interface Review {
 	id: number;
 	coffee_id: number;
 	taster_id: number;
+	brew_setup_id: number;
 	taster: Taster;
+	brew_setup: BrewSetup;
 	rating: number;
 	comment: string | null;
 	updated_at: string;
@@ -207,6 +209,7 @@ export const api = {
 	reviews: {
 		upsert: (coffeeId: number, data: {
 			taster_id: number;
+			brew_setup_id: number;
 			rating: number;
 			comment?: string;
 			descriptor_ids?: number[];

--- a/frontend/src/lib/components/CoffeeDetail.svelte
+++ b/frontend/src/lib/components/CoffeeDetail.svelte
@@ -51,6 +51,7 @@
 
 	// Review form
 	let editingReviewTasterId = $state<number | null>(null);
+	let reviewBrewSetupId = $state<number | null>(null);
 	let reviewRating = $state(0);
 	let reviewComment = $state('');
 	let reviewDescriptors = $state<number[]>([]);
@@ -98,7 +99,7 @@
 	);
 
 	const unreviewedTasters = $derived(
-		tasters.filter(ta => !coffee?.reviews.some(r => r.taster_id === ta.id))
+		tasters
 	);
 
 	// Edit mode helpers
@@ -156,8 +157,9 @@
 	}
 
 	// Review helpers
-	function startReview(tasterId: number, existing?: { rating: number; comment: string | null; descriptors: { id: number }[] }) {
+	function startReview(tasterId: number, brewSetupId?: number, existing?: { rating: number; comment: string | null; descriptors: { id: number }[] }) {
 		editingReviewTasterId = tasterId;
+		reviewBrewSetupId = brewSetupId ?? brewSetupsList.find(s => s.is_default)?.id ?? brewSetupsList[0]?.id ?? null;
 		reviewRating = existing?.rating ?? 0;
 		reviewComment = existing?.comment ?? '';
 		reviewDescriptors = existing?.descriptors.map(d => d.id) ?? [];
@@ -165,15 +167,17 @@
 
 	function cancelReview() {
 		editingReviewTasterId = null;
+		reviewBrewSetupId = null;
 		reviewRating = 0;
 		reviewComment = '';
 		reviewDescriptors = [];
 	}
 
 	async function saveReview() {
-		if (!editingReviewTasterId || reviewRating === 0) return;
+		if (!editingReviewTasterId || !reviewBrewSetupId || reviewRating === 0) return;
 		await api.reviews.upsert(coffeeId, {
 			taster_id: editingReviewTasterId,
+			brew_setup_id: reviewBrewSetupId,
 			rating: reviewRating,
 			comment: reviewComment.trim() || undefined,
 			descriptor_ids: reviewDescriptors.length > 0 ? reviewDescriptors : undefined,
@@ -688,6 +692,8 @@
 					{#if editingReviewTasterId === review.taster_id}
 						<ReviewForm
 							tasterName={review.taster.name}
+							brewSetups={brewSetupsList}
+							bind:brewSetupId={reviewBrewSetupId}
 							bind:rating={reviewRating}
 							bind:comment={reviewComment}
 							bind:descriptorIds={reviewDescriptors}
@@ -701,11 +707,12 @@
 							<div class="flex items-center justify-between">
 								<div class="flex items-center gap-2">
 									<span class="text-base font-semibold text-stone-700">{review.taster.name}</span>
+									<span class="text-xs bg-stone-100 text-stone-500 rounded-md px-2 py-0.5">{review.brew_setup.manufacturer}{review.brew_setup.model ? ` ${review.brew_setup.model}` : ''}</span>
 									<StarRating rating={review.rating} />
 									<span class="text-sm text-stone-400 tabular-nums">{review.rating}/10</span>
 								</div>
 								<div class="flex gap-2 items-center">
-									<button onclick={() => startReview(review.taster_id, review)} class="px-3 py-1 text-sm text-stone-400 hover:text-amber-600 transition-colors rounded hover:bg-card-inset">edit</button>
+									<button onclick={() => startReview(review.taster_id, review.brew_setup_id, review)} class="px-3 py-1 text-sm text-stone-400 hover:text-amber-600 transition-colors rounded hover:bg-card-inset">edit</button>
 									<button onclick={() => deleteReview(review.id)} class="p-1.5 text-stone-300 hover:text-red-400 transition-colors rounded hover:bg-card-inset" title={$t('detail.delete')}>
 										<img src="/img/knockbox.png" alt="delete" class="w-7 h-7 opacity-50" />
 									</button>
@@ -723,9 +730,11 @@
 					{/if}
 				{/each}
 
-				{#if editingReviewTasterId && !coffee.reviews.some(r => r.taster_id === editingReviewTasterId)}
+				{#if editingReviewTasterId && !coffee.reviews.some(r => r.taster_id === editingReviewTasterId && r.brew_setup_id === reviewBrewSetupId)}
 					<ReviewForm
 						tasterName={tasters.find(ta => ta.id === editingReviewTasterId)?.name ?? ''}
+						brewSetups={brewSetupsList}
+						bind:brewSetupId={reviewBrewSetupId}
 						bind:rating={reviewRating}
 						bind:comment={reviewComment}
 						bind:descriptorIds={reviewDescriptors}

--- a/frontend/src/lib/components/ReviewForm.svelte
+++ b/frontend/src/lib/components/ReviewForm.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { Descriptor } from '$lib/api';
+	import type { Descriptor, BrewSetup } from '$lib/api';
 	import { t } from '$lib/i18n';
 	import StarRating from './StarRating.svelte';
 	import DescriptorAutocomplete from './DescriptorAutocomplete.svelte';
@@ -7,6 +7,8 @@
 
 	let {
 		tasterName,
+		brewSetups,
+		brewSetupId = $bindable(),
 		rating = $bindable(),
 		comment = $bindable(),
 		descriptorIds = $bindable(),
@@ -16,6 +18,8 @@
 		onCancel,
 	}: {
 		tasterName: string;
+		brewSetups: BrewSetup[];
+		brewSetupId: number | null;
 		rating: number;
 		comment: string;
 		descriptorIds: number[];
@@ -36,11 +40,21 @@
 		<StarRating {rating} interactive onRate={(v) => rating = v} />
 		{#if rating > 0}<span class="text-xs text-stone-400 tabular-nums">{rating}/10</span>{/if}
 	</div>
+	<div class="flex items-center gap-2">
+		<select bind:value={brewSetupId}
+			class="text-sm text-stone-600 bg-card-inset rounded-lg px-3 py-1.5 border border-stone-200 focus:outline-none focus:ring-2 focus:ring-amber-400/50 cursor-pointer">
+			{#each brewSetups as s}
+				<option value={s.id}>
+					{s.manufacturer}{s.model ? ` ${s.model}` : ''}{s.basket_grams ? ` ${s.basket_grams}g` : ''}
+				</option>
+			{/each}
+		</select>
+	</div>
 	<textarea bind:value={comment} rows={2} placeholder={$t('tasting.comment_placeholder')}
 		class="w-full px-2 py-1.5 rounded border border-stone-200 text-sm bg-card focus:outline-none focus:ring-2 focus:ring-amber-400/50 resize-none"></textarea>
 	<DescriptorAutocomplete {descriptors} selected={descriptorIds} suggested={suggestedDescriptorIds} onToggle={toggleDescriptor} />
 	<div class="flex gap-2">
-		<button onclick={onSave} disabled={rating === 0}
+		<button onclick={onSave} disabled={rating === 0 || !brewSetupId}
 			class="px-4 py-2 bg-amber-700 text-white rounded-lg text-sm hover:bg-amber-800 disabled:opacity-50">{$t('tasting.save')}</button>
 		<button onclick={onCancel} class="px-4 py-2 text-stone-400 text-sm">{$t('tasting.cancel')}</button>
 	</div>


### PR DESCRIPTION
## Summary
- Reviews now keyed by `(coffee_id, taster_id, brew_setup_id)` — same person can rate same coffee differently per brew method
- Migration backfills existing reviews with the default brew setup (no data loss)
- Review form includes brew method selector (defaults to default brew setup)
- Each review shows brew method badge (e.g. "Gaggia Classic EVO")
- Sidebar `person_rating` filters by default brew setup
- `avg_rating` averages across all methods (unchanged)

Closes #7

## Test plan
- [x] 92 backend tests pass (new: `test_per_method_reviews`)
- [x] ruff clean, svelte-check 0 errors
- [ ] Create review for espresso, then another for pourover — both show
- [ ] Edit existing review — upserts correctly
- [ ] Sidebar rating reflects default brew setup's rating

🤖 Generated with [Claude Code](https://claude.com/claude-code)