### PR TITLE
Context switcher — grinder/brew in header

### DIFF
--- a/backend/app/routers/coffees.py
+++ b/backend/app/routers/coffees.py
@@ -46,6 +46,8 @@ def list_coffees(
     search: str | None = Query(None, description="Search by name or roastery"),
     descriptor_id: int | None = Query(None, description="Filter by roastery descriptor"),
     taster_id: int | None = Query(None, description="Active person — returns their rating"),
+    grinder_id: int | None = Query(None, description="Active grinder — returns grind setting"),
+    brew_setup_id: int | None = Query(None, description="Active brew setup — filters ratings and grind"),
     db: Session = Depends(get_db),
 ):
     query = db.query(Coffee).options(
@@ -79,30 +81,36 @@ def list_coffees(
         .all()
     )
 
-    # Shared: default equipment (used for person_rating + default_grind)
-    default_grinder = db.query(Grinder).filter(Grinder.is_default.is_(True)).first()
-    default_setup = db.query(BrewSetup).filter(BrewSetup.is_default.is_(True)).first()
+    # Resolve active equipment (explicit IDs or fallback to is_default)
+    active_grinder = (
+        db.query(Grinder).filter(Grinder.id == grinder_id).first() if grinder_id
+        else db.query(Grinder).filter(Grinder.is_default.is_(True)).first()
+    )
+    active_setup = (
+        db.query(BrewSetup).filter(BrewSetup.id == brew_setup_id).first() if brew_setup_id
+        else db.query(BrewSetup).filter(BrewSetup.is_default.is_(True)).first()
+    )
 
-    # Bulk: person ratings for default brew setup (1 query)
+    # Bulk: person ratings for active brew setup (1 query)
     person_ratings = {}
-    if taster_id and default_setup:
+    if taster_id and active_setup:
         person_ratings = dict(
             db.query(Review.coffee_id, Review.rating)
             .filter(
                 Review.coffee_id.in_(coffee_ids),
                 Review.taster_id == taster_id,
-                Review.brew_setup_id == default_setup.id,
+                Review.brew_setup_id == active_setup.id,
             )
             .all()
         )
 
-    # Bulk: default grind settings (1+2 queries instead of 3N)
+    # Bulk: grind settings for active grinder + brew setup
     default_grinds: dict[int, float] = {}
-    if default_grinder and default_setup:
+    if active_grinder and active_setup:
         for row in db.query(GrinderSetting.coffee_id, GrinderSetting.setting).filter(
             GrinderSetting.coffee_id.in_(coffee_ids),
-            GrinderSetting.grinder_id == default_grinder.id,
-            GrinderSetting.brew_setup_id == default_setup.id,
+            GrinderSetting.grinder_id == active_grinder.id,
+            GrinderSetting.brew_setup_id == active_setup.id,
         ).all():
             default_grinds[row.coffee_id] = row.setting
 
@@ -113,8 +121,8 @@ def list_coffees(
         data.avg_rating = round(avg, 1) if avg else None
         data.person_rating = person_ratings.get(c.id)
         data.default_grind = default_grinds.get(c.id)
-        if default_grinder:
-            data.default_grind_step = default_grinder.step or 1
+        if active_grinder:
+            data.default_grind_step = active_grinder.step or 1
         result.append(data)
     return result
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -49,7 +49,7 @@ wheels = [
 
 [[package]]
 name = "beanbrain"
-version = "0.3.2"
+version = "0.3.3"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -173,10 +173,12 @@ export const BREW_METHOD_TYPES: BrewMethodType[] = [
 
 export const api = {
 	coffees: {
-		list: (search?: string, tasterId?: number | null) => {
+		list: (opts?: { search?: string; tasterId?: number | null; grinderId?: number | null; brewSetupId?: number | null }) => {
 			const params = new URLSearchParams();
-			if (search) params.set('search', search);
-			if (tasterId) params.set('taster_id', String(tasterId));
+			if (opts?.search) params.set('search', opts.search);
+			if (opts?.tasterId) params.set('taster_id', String(opts.tasterId));
+			if (opts?.grinderId) params.set('grinder_id', String(opts.grinderId));
+			if (opts?.brewSetupId) params.set('brew_setup_id', String(opts.brewSetupId));
 			const qs = params.toString();
 			return request<CoffeeListItem[]>(`/coffees/${qs ? `?${qs}` : ''}`);
 		},

--- a/frontend/src/lib/components/ContextSwitcher.svelte
+++ b/frontend/src/lib/components/ContextSwitcher.svelte
@@ -1,0 +1,230 @@
+<script lang="ts">
+	import { api, type Taster, type Grinder, type BrewSetup } from '$lib/api';
+	import { activePerson } from '$lib/personStore';
+	import { activeGrinder, activeBrewSetup } from '$lib/contextStore';
+	import { t } from '$lib/i18n';
+	import SwitcherPopover from './SwitcherPopover.svelte';
+
+	let { onChange }: { onChange: () => void } = $props();
+
+	let tasters = $state<Taster[]>([]);
+	let grinders = $state<Grinder[]>([]);
+	let brewSetups = $state<BrewSetup[]>([]);
+
+	let openPanel = $state<'person' | 'grinder' | 'brew' | null>(null);
+
+	let currentPersonId = $state<number | null>(null);
+	let currentGrinderId = $state<number | null>(null);
+	let currentBrewSetupId = $state<number | null>(null);
+
+	activePerson.subscribe(v => currentPersonId = v);
+	activeGrinder.subscribe(v => currentGrinderId = v);
+	activeBrewSetup.subscribe(v => currentBrewSetupId = v);
+
+	async function loadAll() {
+		[tasters, grinders, brewSetups] = await Promise.all([
+			api.tasters.list(),
+			api.grinders.list(),
+			api.brewSetups.list(),
+		]);
+
+		// Auto-select defaults if nothing stored
+		if (currentGrinderId === null || !grinders.some(g => g.id === currentGrinderId)) {
+			const def = grinders.find(g => g.is_default) ?? grinders[0];
+			if (def) activeGrinder.set(def.id);
+		}
+		if (currentBrewSetupId === null || !brewSetups.some(s => s.id === currentBrewSetupId)) {
+			const def = brewSetups.find(s => s.is_default) ?? brewSetups[0];
+			if (def) activeBrewSetup.set(def.id);
+		}
+		if (currentPersonId !== null && !tasters.some(t => t.id === currentPersonId)) {
+			activePerson.set(null);
+		}
+	}
+
+	$effect(() => { loadAll(); });
+
+	function selectPerson(id: number | null) {
+		activePerson.set(id);
+		openPanel = null;
+		onChange();
+	}
+
+	function selectGrinder(id: number | null) {
+		if (id !== null) activeGrinder.set(id);
+		openPanel = null;
+		onChange();
+	}
+
+	function selectBrewSetup(id: number | null) {
+		if (id !== null) activeBrewSetup.set(id);
+		openPanel = null;
+		onChange();
+	}
+
+	async function addPerson(name: string) {
+		const created = await api.tasters.create(name);
+		await loadAll();
+		selectPerson(created.id);
+	}
+
+	async function addGrinder(name: string) {
+		const created = await api.grinders.create({ manufacturer: name });
+		await loadAll();
+		selectGrinder(created.id);
+	}
+
+	async function addBrewSetup(name: string) {
+		const created = await api.brewSetups.create({ method_type: 'espresso', manufacturer: name });
+		await loadAll();
+		selectBrewSetup(created.id);
+	}
+
+	async function removePerson(id: number) {
+		await api.tasters.delete(id);
+		if (currentPersonId === id) activePerson.set(null);
+		await loadAll();
+		onChange();
+	}
+
+	async function removeGrinder(id: number) {
+		await api.grinders.delete(id);
+		if (currentGrinderId === id) {
+			const next = grinders.find(g => g.id !== id);
+			activeGrinder.set(next?.id ?? null);
+		}
+		await loadAll();
+		onChange();
+	}
+
+	async function removeBrewSetup(id: number) {
+		await api.brewSetups.delete(id);
+		if (currentBrewSetupId === id) {
+			const next = brewSetups.find(s => s.id !== id);
+			activeBrewSetup.set(next?.id ?? null);
+		}
+		await loadAll();
+		onChange();
+	}
+
+	const currentPerson = $derived(tasters.find(t => t.id === currentPersonId));
+	const currentGrinder = $derived(grinders.find(g => g.id === currentGrinderId));
+	const currentBrewSetup = $derived(brewSetups.find(s => s.id === currentBrewSetupId));
+
+	const personItems = $derived(tasters.map(t => ({
+		id: t.id,
+		label: t.name,
+		icon: '/img/tab-person.png',
+	})));
+
+	const grinderItems = $derived(grinders.map(g => ({
+		id: g.id,
+		label: `${g.manufacturer}${g.model ? ` ${g.model}` : ''}`,
+		sublabel: g.range_max ? `${g.range_min}–${g.range_max} step ${g.step}` : `step ${g.step}`,
+		icon: `/img/grinder-${g.kind === 'manual' ? 'manual' : 'auto'}.png`,
+	})));
+
+	const brewItems = $derived(brewSetups.map(s => ({
+		id: s.id,
+		label: `${s.manufacturer}${s.model ? ` ${s.model}` : ''}`,
+		sublabel: s.basket_grams ? `${s.basket_grams}g` : undefined,
+		icon: `/img/method-${s.method_type}.png`,
+	})));
+
+	function toggle(panel: 'person' | 'grinder' | 'brew') {
+		openPanel = openPanel === panel ? null : panel;
+	}
+
+	function handleClickOutside(event: MouseEvent) {
+		const target = event.target as HTMLElement;
+		if (!target.closest('.context-switcher')) {
+			openPanel = null;
+		}
+	}
+</script>
+
+<svelte:window onclick={handleClickOutside} />
+
+<div class="context-switcher flex items-center gap-1.5">
+	<!-- Person -->
+	<div class="relative">
+		<button
+			onclick={() => toggle('person')}
+			class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sm font-medium
+				hover:bg-parchment transition-colors
+				{openPanel === 'person' ? 'bg-parchment' : 'bg-card-inset'} text-stone-500"
+			title={currentPerson?.name ?? $t('person.everyone')}
+		>
+			<img src="/img/tab-person.png" alt="" class="w-6 h-6 opacity-60" />
+			<span class="max-w-[80px] truncate hidden md:inline">{currentPerson?.name ?? $t('person.everyone')}</span>
+		</button>
+		{#if openPanel === 'person'}
+			<div class="absolute right-0 top-full mt-1">
+				<SwitcherPopover
+					items={personItems}
+					activeId={currentPersonId}
+					everyoneLabel={$t('person.everyone')}
+					addPlaceholder={$t('persons.add_placeholder')}
+					addLabel={$t('persons.add')}
+					onSelect={selectPerson}
+					onAdd={addPerson}
+					onRemove={removePerson}
+				/>
+			</div>
+		{/if}
+	</div>
+
+	<!-- Grinder -->
+	<div class="relative">
+		<button
+			onclick={() => toggle('grinder')}
+			class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sm font-medium
+				hover:bg-parchment transition-colors
+				{openPanel === 'grinder' ? 'bg-parchment' : 'bg-card-inset'} text-stone-500"
+			title={currentGrinder ? `${currentGrinder.manufacturer}${currentGrinder.model ? ` ${currentGrinder.model}` : ''}` : 'Grinder'}
+		>
+			<img src="/img/grinder-{currentGrinder?.kind === 'manual' ? 'manual' : 'auto'}.png" alt="" class="w-6 h-6 opacity-60" />
+			<span class="max-w-[80px] truncate hidden lg:inline">{currentGrinder?.manufacturer ?? '—'}</span>
+		</button>
+		{#if openPanel === 'grinder'}
+			<div class="absolute right-0 top-full mt-1">
+				<SwitcherPopover
+					items={grinderItems}
+					activeId={currentGrinderId}
+					addPlaceholder={$t('grinding.manufacturer_placeholder')}
+					addLabel={$t('grinding.add')}
+					onSelect={selectGrinder}
+					onAdd={addGrinder}
+					onRemove={removeGrinder}
+				/>
+			</div>
+		{/if}
+	</div>
+
+	<!-- Brew Setup -->
+	<div class="relative">
+		<button
+			onclick={() => toggle('brew')}
+			class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sm font-medium
+				hover:bg-parchment transition-colors
+				{openPanel === 'brew' ? 'bg-parchment' : 'bg-card-inset'} text-stone-500"
+			title={currentBrewSetup ? `${currentBrewSetup.manufacturer}${currentBrewSetup.model ? ` ${currentBrewSetup.model}` : ''}` : 'Brew'}
+		>
+			<img src="/img/method-{currentBrewSetup?.method_type ?? 'espresso'}.png" alt="" class="w-6 h-6 opacity-60" />
+			<span class="max-w-[80px] truncate hidden lg:inline">{currentBrewSetup?.manufacturer ?? '—'}</span>
+		</button>
+		{#if openPanel === 'brew'}
+			<div class="absolute right-0 top-full mt-1">
+				<SwitcherPopover
+					items={brewItems}
+					activeId={currentBrewSetupId}
+					addPlaceholder={$t('brewing.manufacturer_placeholder')}
+					addLabel={$t('brewing.add')}
+					onSelect={selectBrewSetup}
+					onAdd={addBrewSetup}
+					onRemove={removeBrewSetup}
+				/>
+			</div>
+		{/if}
+	</div>
+</div>

--- a/frontend/src/lib/components/SwitcherPopover.svelte
+++ b/frontend/src/lib/components/SwitcherPopover.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+	import { t } from '$lib/i18n';
+	import Icons from './Icons.svelte';
+
+	interface Item {
+		id: number;
+		label: string;
+		sublabel?: string;
+		icon?: string;
+	}
+
+	let {
+		items,
+		activeId,
+		everyoneLabel = '',
+		addPlaceholder,
+		addLabel,
+		onSelect,
+		onAdd,
+		onRemove,
+	}: {
+		items: Item[];
+		activeId: number | null;
+		everyoneLabel?: string;
+		addPlaceholder: string;
+		addLabel: string;
+		onSelect: (id: number | null) => void;
+		onAdd: (name: string) => void;
+		onRemove?: (id: number) => void;
+	} = $props();
+
+	let adding = $state(false);
+	let newName = $state('');
+
+	function handleAdd() {
+		if (!newName.trim()) return;
+		onAdd(newName.trim());
+		newName = '';
+		adding = false;
+	}
+</script>
+
+<div class="w-72 bg-card rounded-xl border border-stone-200 shadow-lg z-50 overflow-hidden">
+	{#if everyoneLabel}
+		<button
+			onclick={() => onSelect(null)}
+			class="w-full text-left px-4 py-3 text-sm hover:bg-amber-50/50 transition-colors flex items-center gap-3
+				{activeId === null ? 'bg-amber-50 text-amber-700 font-medium' : 'text-stone-600'}"
+		>
+			<span class="w-6 h-6 rounded-full bg-stone-100 flex items-center justify-center text-xs text-stone-400">
+				<Icons icon="users" size={14} />
+			</span>
+			{everyoneLabel}
+		</button>
+	{/if}
+
+	{#if items.length > 0}
+		<div class="border-t border-stone-100">
+			{#each items as item}
+				<div class="flex items-center hover:bg-amber-50/50 transition-colors
+					{activeId === item.id ? 'bg-amber-50' : ''}">
+					<button
+						onclick={() => onSelect(item.id)}
+						class="flex-1 text-left px-4 py-3 text-sm flex items-center gap-3 min-w-0
+							{activeId === item.id ? 'text-amber-700 font-medium' : 'text-stone-600'}"
+					>
+						{#if item.icon}
+							<img src={item.icon} alt="" class="w-6 h-6 opacity-60 flex-shrink-0" />
+						{/if}
+						<div class="min-w-0 flex-1">
+							<span class="truncate block">{item.label}</span>
+							{#if item.sublabel}
+								<span class="text-xs text-stone-400 truncate block">{item.sublabel}</span>
+							{/if}
+						</div>
+					</button>
+					{#if onRemove}
+						<button
+							onclick={(e) => { e.stopPropagation(); onRemove(item.id); }}
+							class="p-2 mr-2 text-stone-300 hover:text-red-400 transition-colors rounded flex-shrink-0"
+							title={$t('detail.delete')}
+						>
+							<img src="/img/knockbox.png" alt="delete" class="w-5 h-5 opacity-50" />
+						</button>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	{/if}
+
+	<div class="border-t border-stone-100">
+		{#if adding}
+			<div class="p-3 flex gap-2">
+				<input
+					type="text"
+					bind:value={newName}
+					placeholder={addPlaceholder}
+					class="flex-1 px-3 py-2 rounded-lg border border-stone-200 text-sm bg-card
+						focus:outline-none focus:ring-2 focus:ring-amber-400/50"
+					onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleAdd(); } if (e.key === 'Escape') { adding = false; newName = ''; } }}
+				/>
+				<button
+					onclick={handleAdd}
+					disabled={!newName.trim()}
+					class="px-3 py-2 bg-amber-700 text-white rounded-lg text-sm hover:bg-amber-800
+						transition-colors disabled:opacity-50"
+				>{addLabel}</button>
+			</div>
+		{:else}
+			<button
+				onclick={(e) => { e.stopPropagation(); adding = true; }}
+				class="w-full text-left px-4 py-3 text-sm text-amber-600 hover:bg-amber-50/50 transition-colors flex items-center gap-3"
+			>
+				<Icons icon="plus" size={14} />
+				{addLabel}
+			</button>
+		{/if}
+	</div>
+</div>

--- a/frontend/src/lib/contextStore.ts
+++ b/frontend/src/lib/contextStore.ts
@@ -1,0 +1,23 @@
+import { writable } from 'svelte/store';
+
+const isBrowser = typeof window !== 'undefined';
+
+function persistentStore(key: string) {
+	const stored = isBrowser ? localStorage.getItem(key) : null;
+	const store = writable<number | null>(stored ? parseInt(stored, 10) : null);
+
+	store.subscribe((value) => {
+		if (isBrowser) {
+			if (value !== null) {
+				localStorage.setItem(key, String(value));
+			} else {
+				localStorage.removeItem(key);
+			}
+		}
+	});
+
+	return store;
+}
+
+export const activeGrinder = persistentStore('beanbrain-grinder');
+export const activeBrewSetup = persistentStore('beanbrain-brew-setup');

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,75 +1,57 @@
 <script lang="ts">
-	import { api, type CoffeeListItem, type Grinder, type BrewSetup, type Roastery } from '$lib/api';
+	import { api, type CoffeeListItem, type Roastery } from '$lib/api';
 	import { lang, type Lang } from '$lib/lang';
 	import { activePerson } from '$lib/personStore';
+	import { activeGrinder, activeBrewSetup } from '$lib/contextStore';
 	import { t } from '$lib/i18n';
 	import CoffeeSidebar from '$lib/components/CoffeeSidebar.svelte';
 	import CoffeeDetail from '$lib/components/CoffeeDetail.svelte';
 	import AddCoffeePanel from '$lib/components/AddCoffeePanel.svelte';
-	import GrindingSidebar from '$lib/components/GrindingSidebar.svelte';
-	import GrinderDetail from '$lib/components/GrinderDetail.svelte';
-	import AddGrinderPanel from '$lib/components/AddGrinderPanel.svelte';
-	import BrewingSidebar from '$lib/components/BrewingSidebar.svelte';
-	import BrewSetupDetail from '$lib/components/BrewSetupDetail.svelte';
-	import BrewMethodPicker from '$lib/components/BrewMethodPicker.svelte';
-	import AddBrewSetupPanel from '$lib/components/AddBrewSetupPanel.svelte';
 	import RoasterySidebar from '$lib/components/RoasterySidebar.svelte';
 	import RoasteryDetail from '$lib/components/RoasteryDetail.svelte';
 	import AddRoasteryPanel from '$lib/components/AddRoasteryPanel.svelte';
-	import PersonSwitcher from '$lib/components/PersonSwitcher.svelte';
+	import ContextSwitcher from '$lib/components/ContextSwitcher.svelte';
 	import EmptyState from '$lib/components/EmptyState.svelte';
 
-	type Tab = 'coffee' | 'grinding' | 'brewing' | 'roasteries';
+	type Tab = 'coffee' | 'roasteries';
 	type CoffeePanel = { type: 'empty' } | { type: 'detail'; id: number } | { type: 'new' };
-	type GrinderPanel = { type: 'empty' } | { type: 'detail'; id: number } | { type: 'new' };
-	type BrewPanel = { type: 'empty' } | { type: 'detail'; id: number } | { type: 'pick_method' } | { type: 'new'; methodType: string; hasBasket: boolean };
 	type RoasteryPanel = { type: 'empty' } | { type: 'detail'; id: number } | { type: 'new' };
 
 	let activeTab = $state<Tab>('coffee');
 	let coffees = $state<CoffeeListItem[]>([]);
 	let coffeePanel = $state<CoffeePanel>({ type: 'empty' });
 
-	let grinders = $state<Grinder[]>([]);
-	let grinderPanel = $state<GrinderPanel>({ type: 'empty' });
-
-	let brewSetups = $state<BrewSetup[]>([]);
-	let brewPanel = $state<BrewPanel>({ type: 'empty' });
-
 	let roasteriesList = $state<Roastery[]>([]);
 	let roasteryPanel = $state<RoasteryPanel>({ type: 'empty' });
 
 	let currentLang = $state<Lang>('en');
 	let currentPersonId = $state<number | null>(null);
+	let currentGrinderId = $state<number | null>(null);
+	let currentBrewSetupId = $state<number | null>(null);
 
 	lang.subscribe(v => currentLang = v);
 	activePerson.subscribe(v => currentPersonId = v);
+	activeGrinder.subscribe(v => currentGrinderId = v);
+	activeBrewSetup.subscribe(v => currentBrewSetupId = v);
 
 	const tabDefs: { id: Tab; key: string; img: string }[] = [
 		{ id: 'coffee', key: 'tab.coffee', img: '/img/tab-coffee.png' },
-		{ id: 'grinding', key: 'tab.grinding', img: '/img/tab-grinder.png' },
-		{ id: 'brewing', key: 'tab.brewing', img: '/img/tab-machine.png' },
 		{ id: 'roasteries', key: 'tab.roasteries', img: '/img/tab-roastery.png' },
 	];
 
 	async function loadCoffees() {
-		coffees = await api.coffees.list(undefined, currentPersonId);
-	}
-
-	async function loadGrinders() {
-		grinders = await api.grinders.list();
-	}
-
-	async function loadBrewSetups() {
-		brewSetups = await api.brewSetups.list();
+		coffees = await api.coffees.list({
+			tasterId: currentPersonId,
+			grinderId: currentGrinderId,
+			brewSetupId: currentBrewSetupId,
+		});
 	}
 
 	async function loadRoasteries() {
 		roasteriesList = await api.roasteries.list();
 	}
 
-	$effect(() => { currentPersonId; loadCoffees(); });
-	$effect(() => { if (activeTab === 'grinding') loadGrinders(); });
-	$effect(() => { if (activeTab === 'brewing') loadBrewSetups(); });
+	$effect(() => { currentPersonId; currentGrinderId; currentBrewSetupId; loadCoffees(); });
 	$effect(() => { if (activeTab === 'roasteries') loadRoasteries(); });
 
 	function selectCoffee(id: number) {
@@ -84,57 +66,6 @@
 	async function onCoffeeDeleted() {
 		await loadCoffees();
 		coffeePanel = { type: 'empty' };
-	}
-
-	// Grinder handlers
-	function selectGrinder(id: number) {
-		grinderPanel = { type: 'detail', id };
-	}
-
-	async function onGrinderCreated(id: number) {
-		await loadGrinders();
-		grinderPanel = { type: 'detail', id };
-	}
-
-	async function onGrinderUpdated() {
-		await loadGrinders();
-		await loadCoffees();
-		// Re-select to refresh detail
-		if (grinderPanel.type === 'detail') {
-			grinderPanel = { ...grinderPanel };
-		}
-	}
-
-	async function onGrinderDeleted() {
-		await loadGrinders();
-		grinderPanel = { type: 'empty' };
-	}
-
-	// Brew setup handlers
-	function selectBrewSetup(id: number) {
-		brewPanel = { type: 'detail', id };
-	}
-
-	function onMethodPicked(methodType: string, hasBasket: boolean) {
-		brewPanel = { type: 'new', methodType, hasBasket };
-	}
-
-	async function onBrewSetupCreated(id: number) {
-		await loadBrewSetups();
-		brewPanel = { type: 'detail', id };
-	}
-
-	async function onBrewSetupUpdated() {
-		await loadBrewSetups();
-		await loadCoffees();
-		if (brewPanel.type === 'detail') {
-			brewPanel = { ...brewPanel };
-		}
-	}
-
-	async function onBrewSetupDeleted() {
-		await loadBrewSetups();
-		brewPanel = { type: 'empty' };
 	}
 
 	// Roastery handlers
@@ -166,17 +97,7 @@
 	const appVersion = __APP_VERSION__;
 
 	const selectedCoffeeId = $derived(coffeePanel.type === 'detail' ? coffeePanel.id : null);
-	const selectedGrinderId = $derived(grinderPanel.type === 'detail' ? grinderPanel.id : null);
-	const selectedBrewSetupId = $derived(brewPanel.type === 'detail' ? brewPanel.id : null);
-
 	const selectedRoasteryId = $derived(roasteryPanel.type === 'detail' ? roasteryPanel.id : null);
-
-	const selectedGrinder = $derived(
-		selectedGrinderId != null ? grinders.find(g => g.id === selectedGrinderId) ?? null : null
-	);
-	const selectedBrewSetup = $derived(
-		selectedBrewSetupId != null ? brewSetups.find(s => s.id === selectedBrewSetupId) ?? null : null
-	);
 	const selectedRoastery = $derived(
 		selectedRoasteryId != null ? roasteriesList.find(r => r.id === selectedRoasteryId) ?? null : null
 	);
@@ -188,15 +109,11 @@
 	// On mobile, detail panel is shown = sidebar hidden
 	const showingDetail = $derived(
 		(activeTab === 'coffee' && coffeePanel.type !== 'empty') ||
-		(activeTab === 'grinding' && grinderPanel.type !== 'empty') ||
-		(activeTab === 'brewing' && brewPanel.type !== 'empty') ||
 		(activeTab === 'roasteries' && roasteryPanel.type !== 'empty')
 	);
 
 	function mobileBack() {
 		if (activeTab === 'coffee') coffeePanel = { type: 'empty' };
-		else if (activeTab === 'grinding') grinderPanel = { type: 'empty' };
-		else if (activeTab === 'brewing') brewPanel = { type: 'empty' };
 		else if (activeTab === 'roasteries') roasteryPanel = { type: 'empty' };
 	}
 </script>
@@ -230,7 +147,7 @@
 
 			<div class="flex items-center gap-2 xl:gap-3">
 				<span class="hidden md:inline text-xs text-stone-300 font-mono">v{appVersion}</span>
-				<PersonSwitcher onChange={loadCoffees} />
+				<ContextSwitcher onChange={loadCoffees} />
 				<button
 					onclick={toggleLang}
 					class="flex items-center gap-1.5 px-2 xl:px-3 py-2 rounded-lg text-sm font-medium
@@ -269,50 +186,6 @@
 						<CoffeeDetail coffeeId={coffeePanel.id} onDeleted={onCoffeeDeleted} onUpdated={loadCoffees} onBack={isMobile ? mobileBack : () => coffeePanel = { type: 'empty' }} />
 					{:else if coffeePanel.type === 'new'}
 						<AddCoffeePanel onCreated={onCoffeeCreated} onCancel={isMobile ? mobileBack : () => coffeePanel = { type: 'empty' }} />
-					{/if}
-				</div>
-			{/if}
-
-		{:else if activeTab === 'grinding'}
-			{#if !isMobile || !showingDetail}
-				<GrindingSidebar
-					{grinders}
-					selectedId={selectedGrinderId}
-					onSelect={selectGrinder}
-					onAdd={() => grinderPanel = { type: 'new' }}
-				/>
-			{/if}
-			{#if !isMobile || showingDetail}
-				<div class="flex-1 overflow-y-auto bg-parchment" style="background-image: url('/img/bg-pattern.png'); background-repeat: repeat;">
-					{#if grinderPanel.type === 'empty'}
-						<EmptyState img="many-grinders.png" title={$t('grinding.select')} />
-					{:else if grinderPanel.type === 'detail' && selectedGrinder}
-						<GrinderDetail grinder={selectedGrinder} onUpdated={onGrinderUpdated} onDeleted={onGrinderDeleted} onBack={isMobile ? mobileBack : () => grinderPanel = { type: 'empty' }} />
-					{:else if grinderPanel.type === 'new'}
-						<AddGrinderPanel onCreated={onGrinderCreated} onCancel={isMobile ? mobileBack : () => grinderPanel = { type: 'empty' }} />
-					{/if}
-				</div>
-			{/if}
-
-		{:else if activeTab === 'brewing'}
-			{#if !isMobile || !showingDetail}
-				<BrewingSidebar
-					{brewSetups}
-					selectedId={selectedBrewSetupId}
-					onSelect={selectBrewSetup}
-					onAdd={() => brewPanel = { type: 'pick_method' }}
-				/>
-			{/if}
-			{#if !isMobile || showingDetail}
-				<div class="flex-1 overflow-y-auto bg-parchment" style="background-image: url('/img/bg-pattern.png'); background-repeat: repeat;">
-					{#if brewPanel.type === 'empty'}
-						<EmptyState img="many-brewmethods.png" title={$t('brewing.select')} />
-					{:else if brewPanel.type === 'detail' && selectedBrewSetup}
-						<BrewSetupDetail brewSetup={selectedBrewSetup} onUpdated={onBrewSetupUpdated} onDeleted={onBrewSetupDeleted} onBack={isMobile ? mobileBack : () => brewPanel = { type: 'empty' }} />
-					{:else if brewPanel.type === 'pick_method'}
-						<BrewMethodPicker onPicked={onMethodPicked} onCancel={isMobile ? mobileBack : () => brewPanel = { type: 'empty' }} />
-					{:else if brewPanel.type === 'new'}
-						<AddBrewSetupPanel methodType={brewPanel.methodType} hasBasket={brewPanel.hasBasket} onCreated={onBrewSetupCreated} onCancel={isMobile ? mobileBack : () => brewPanel = { type: 'empty' }} />
 					{/if}
 				</div>
 			{/if}


### PR DESCRIPTION
## Summary
- 3 compact context selectors in header: person, grinder, brew method
- Each has quick-switch popover with item list, add new, remove
- Grind/Brew sidebar tabs removed (tab bar: Coffee + Roast)
- Coffee list API accepts `grinder_id`/`brew_setup_id` params
- Switching any context instantly refreshes coffee sidebar
- Active grinder/brew stored in localStorage (like person)

Closes #64

## Test plan
- [x] 92 backend tests pass, ruff clean
- [x] svelte-check: 0 errors
- [ ] Switch person → sidebar ratings update
- [ ] Switch grinder → sidebar grind values update
- [ ] Switch brew setup → sidebar grind values update
- [ ] Add new grinder/brew/person from popover
- [ ] Mobile responsive check

🤖 Generated with [Claude Code](https://claude.com/claude-code)