### PR TITLE
Equipment editing — rename, configure, delete with cascades

### DIFF
--- a/backend/app/routers/brew_setups.py
+++ b/backend/app/routers/brew_setups.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from ..database import get_db
-from ..models import BREW_METHOD_TYPES, BrewSetup
+from ..models import BREW_METHOD_TYPES, BrewSetup, GrinderSetting, Review
 from ..schemas import BrewMethodTypeOut, BrewSetupCreate, BrewSetupOut, BrewSetupUpdate
 from ._helpers import clear_default, get_or_404
 
@@ -46,6 +46,14 @@ def update_brew_setup(setup_id: int, data: BrewSetupUpdate, db: Session = Depend
     db.commit()
     db.refresh(setup)
     return setup
+
+
+@router.get("/brew-setups/{setup_id}/dependents")
+def brew_setup_dependents(setup_id: int, db: Session = Depends(get_db)):
+    get_or_404(db, BrewSetup, setup_id, "Brew setup not found")
+    settings = db.query(GrinderSetting).filter(GrinderSetting.brew_setup_id == setup_id).count()
+    reviews = db.query(Review).filter(Review.brew_setup_id == setup_id).count()
+    return {"grinder_settings": settings, "reviews": reviews}
 
 
 @router.delete("/brew-setups/{setup_id}", status_code=204)

--- a/backend/app/routers/grinders.py
+++ b/backend/app/routers/grinders.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from ..database import get_db
-from ..models import Grinder
+from ..models import Grinder, GrinderSetting
 from ..schemas import GrinderCreate, GrinderOut, GrinderUpdate
 from ._helpers import clear_default, get_or_404
 
@@ -36,6 +36,13 @@ def update_grinder(grinder_id: int, data: GrinderUpdate, db: Session = Depends(g
     db.commit()
     db.refresh(grinder)
     return grinder
+
+
+@router.get("/{grinder_id}/dependents")
+def grinder_dependents(grinder_id: int, db: Session = Depends(get_db)):
+    get_or_404(db, Grinder, grinder_id, "Grinder not found")
+    settings = db.query(GrinderSetting).filter(GrinderSetting.grinder_id == grinder_id).count()
+    return {"grinder_settings": settings}
 
 
 @router.delete("/{grinder_id}", status_code=204)

--- a/backend/app/routers/tasters.py
+++ b/backend/app/routers/tasters.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from ..database import get_db
-from ..models import Taster
+from ..models import Taster, Review
 from ..schemas import TasterCreate, TasterOut
 
 router = APIRouter(prefix="/tasters", tags=["tasters"])
@@ -25,6 +25,17 @@ def create_taster(data: TasterCreate, db: Session = Depends(get_db)):
     return taster
 
 
+@router.put("/{taster_id}", response_model=TasterOut)
+def update_taster(taster_id: int, data: TasterCreate, db: Session = Depends(get_db)):
+    taster = db.query(Taster).filter(Taster.id == taster_id).first()
+    if not taster:
+        raise HTTPException(status_code=404, detail="Taster not found")
+    taster.name = data.name
+    db.commit()
+    db.refresh(taster)
+    return taster
+
+
 @router.delete("/{taster_id}", status_code=204)
 def delete_taster(taster_id: int, db: Session = Depends(get_db)):
     taster = db.query(Taster).filter(Taster.id == taster_id).first()
@@ -32,3 +43,12 @@ def delete_taster(taster_id: int, db: Session = Depends(get_db)):
         raise HTTPException(status_code=404, detail="Taster not found")
     db.delete(taster)
     db.commit()
+
+
+@router.get("/{taster_id}/dependents")
+def taster_dependents(taster_id: int, db: Session = Depends(get_db)):
+    """Count records that would be deleted if this taster is removed."""
+    reviews = db.query(Review).filter(Review.taster_id == taster_id).count()
+    return {"reviews": reviews}
+
+

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -238,7 +238,10 @@ export const api = {
 		create: (name: string) => request<Taster>('/tasters/', {
 			method: 'POST', body: JSON.stringify({ name }),
 		}),
+		update: (id: number, data: { name: string }) =>
+			request<Taster>(`/tasters/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
 		delete: (id: number) => request<void>(`/tasters/${id}`, { method: 'DELETE' }),
+		dependents: (id: number) => request<{ reviews: number }>(`/tasters/${id}/dependents`),
 	},
 	descriptors: {
 		list: () => request<Descriptor[]>('/descriptors/'),
@@ -250,6 +253,7 @@ export const api = {
 		update: (id: number, data: Record<string, unknown>) =>
 			request<Grinder>(`/grinders/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
 		delete: (id: number) => request<void>(`/grinders/${id}`, { method: 'DELETE' }),
+		dependents: (id: number) => request<{ grinder_settings: number }>(`/grinders/${id}/dependents`),
 	},
 	brewSetups: {
 		list: () => request<BrewSetup[]>('/brew-setups/'),
@@ -258,6 +262,7 @@ export const api = {
 		update: (id: number, data: Record<string, unknown>) =>
 			request<BrewSetup>(`/brew-setups/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
 		delete: (id: number) => request<void>(`/brew-setups/${id}`, { method: 'DELETE' }),
+		dependents: (id: number) => request<{ grinder_settings: number; reviews: number }>(`/brew-setups/${id}/dependents`),
 	},
 	brewMethodTypes: {
 		list: () => request<BrewMethodType[]>('/brew-method-types'),

--- a/frontend/src/lib/components/ContextSwitcher.svelte
+++ b/frontend/src/lib/components/ContextSwitcher.svelte
@@ -1,17 +1,30 @@
 <script lang="ts">
-	import { api, type Taster, type Grinder, type BrewSetup } from '$lib/api';
+	import { api, type Taster, type Grinder, type BrewSetup, type BrewMethodType } from '$lib/api';
 	import { activePerson } from '$lib/personStore';
 	import { activeGrinder, activeBrewSetup } from '$lib/contextStore';
 	import { t } from '$lib/i18n';
 	import SwitcherPopover from './SwitcherPopover.svelte';
+	import EditDialog from './EditDialog.svelte';
 
 	let { onChange }: { onChange: () => void } = $props();
 
 	let tasters = $state<Taster[]>([]);
 	let grinders = $state<Grinder[]>([]);
 	let brewSetups = $state<BrewSetup[]>([]);
+	let brewMethodTypes = $state<BrewMethodType[]>([]);
 
 	let openPanel = $state<'person' | 'grinder' | 'brew' | null>(null);
+
+	type DialogState =
+		| null
+		| { type: 'person'; mode: 'add' }
+		| { type: 'person'; mode: 'edit'; item: Taster }
+		| { type: 'grinder'; mode: 'add' }
+		| { type: 'grinder'; mode: 'edit'; item: Grinder }
+		| { type: 'brew'; mode: 'add' }
+		| { type: 'brew'; mode: 'edit'; item: BrewSetup };
+
+	let dialogState = $state<DialogState>(null);
 
 	let currentPersonId = $state<number | null>(null);
 	let currentGrinderId = $state<number | null>(null);
@@ -22,13 +35,13 @@
 	activeBrewSetup.subscribe(v => currentBrewSetupId = v);
 
 	async function loadAll() {
-		[tasters, grinders, brewSetups] = await Promise.all([
+		[tasters, grinders, brewSetups, brewMethodTypes] = await Promise.all([
 			api.tasters.list(),
 			api.grinders.list(),
 			api.brewSetups.list(),
+			api.brewMethodTypes.list(),
 		]);
 
-		// Auto-select defaults if nothing stored
 		if (currentGrinderId === null || !grinders.some(g => g.id === currentGrinderId)) {
 			const def = grinders.find(g => g.is_default) ?? grinders[0];
 			if (def) activeGrinder.set(def.id);
@@ -62,46 +75,44 @@
 		onChange();
 	}
 
-	async function addPerson(name: string) {
-		const created = await api.tasters.create(name);
-		await loadAll();
-		selectPerson(created.id);
+	function openAdd(type: 'person' | 'grinder' | 'brew') {
+		openPanel = null;
+		dialogState = { type, mode: 'add' };
 	}
 
-	async function addGrinder(name: string) {
-		const created = await api.grinders.create({ manufacturer: name });
-		await loadAll();
-		selectGrinder(created.id);
+	function openEditPerson(id: number) {
+		openPanel = null;
+		const item = tasters.find(t => t.id === id);
+		if (item) dialogState = { type: 'person', mode: 'edit', item };
 	}
 
-	async function addBrewSetup(name: string) {
-		const created = await api.brewSetups.create({ method_type: 'espresso', manufacturer: name });
-		await loadAll();
-		selectBrewSetup(created.id);
+	function openEditGrinder(id: number) {
+		openPanel = null;
+		const item = grinders.find(g => g.id === id);
+		if (item) dialogState = { type: 'grinder', mode: 'edit', item };
 	}
 
-	async function removePerson(id: number) {
-		await api.tasters.delete(id);
-		if (currentPersonId === id) activePerson.set(null);
-		await loadAll();
-		onChange();
+	function openEditBrewSetup(id: number) {
+		openPanel = null;
+		const item = brewSetups.find(s => s.id === id);
+		if (item) dialogState = { type: 'brew', mode: 'edit', item };
 	}
 
-	async function removeGrinder(id: number) {
-		await api.grinders.delete(id);
-		if (currentGrinderId === id) {
-			const next = grinders.find(g => g.id !== id);
-			activeGrinder.set(next?.id ?? null);
-		}
+	async function onDialogSaved() {
+		dialogState = null;
 		await loadAll();
 		onChange();
 	}
 
-	async function removeBrewSetup(id: number) {
-		await api.brewSetups.delete(id);
-		if (currentBrewSetupId === id) {
-			const next = brewSetups.find(s => s.id !== id);
-			activeBrewSetup.set(next?.id ?? null);
+	async function onDialogDeleted() {
+		const ds = dialogState;
+		dialogState = null;
+		if (ds?.type === 'person' && ds.mode === 'edit' && currentPersonId === ds.item.id) {
+			activePerson.set(null);
+		} else if (ds?.type === 'grinder' && ds.mode === 'edit' && currentGrinderId === ds.item.id) {
+			activeGrinder.set(null);
+		} else if (ds?.type === 'brew' && ds.mode === 'edit' && currentBrewSetupId === ds.item.id) {
+			activeBrewSetup.set(null);
 		}
 		await loadAll();
 		onChange();
@@ -164,11 +175,10 @@
 					items={personItems}
 					activeId={currentPersonId}
 					everyoneLabel={$t('person.everyone')}
-					addPlaceholder={$t('persons.add_placeholder')}
 					addLabel={$t('persons.add')}
 					onSelect={selectPerson}
-					onAdd={addPerson}
-					onRemove={removePerson}
+					onAdd={() => openAdd('person')}
+					onEdit={openEditPerson}
 				/>
 			</div>
 		{/if}
@@ -191,11 +201,10 @@
 				<SwitcherPopover
 					items={grinderItems}
 					activeId={currentGrinderId}
-					addPlaceholder={$t('grinding.manufacturer_placeholder')}
 					addLabel={$t('grinding.add')}
 					onSelect={selectGrinder}
-					onAdd={addGrinder}
-					onRemove={removeGrinder}
+					onAdd={() => openAdd('grinder')}
+					onEdit={openEditGrinder}
 				/>
 			</div>
 		{/if}
@@ -218,13 +227,22 @@
 				<SwitcherPopover
 					items={brewItems}
 					activeId={currentBrewSetupId}
-					addPlaceholder={$t('brewing.manufacturer_placeholder')}
 					addLabel={$t('brewing.add')}
 					onSelect={selectBrewSetup}
-					onAdd={addBrewSetup}
-					onRemove={removeBrewSetup}
+					onAdd={() => openAdd('brew')}
+					onEdit={openEditBrewSetup}
 				/>
 			</div>
 		{/if}
 	</div>
 </div>
+
+{#if dialogState}
+	<EditDialog
+		dialog={dialogState}
+		{brewMethodTypes}
+		onSaved={onDialogSaved}
+		onDeleted={onDialogDeleted}
+		onClose={() => dialogState = null}
+	/>
+{/if}

--- a/frontend/src/lib/components/EditDialog.svelte
+++ b/frontend/src/lib/components/EditDialog.svelte
@@ -1,0 +1,316 @@
+<script lang="ts">
+	import { api, type Grinder, type BrewSetup, type Taster, type BrewMethodType } from '$lib/api';
+	import { t } from '$lib/i18n';
+
+	type DialogType =
+		| { type: 'person'; mode: 'add' }
+		| { type: 'person'; mode: 'edit'; item: Taster }
+		| { type: 'grinder'; mode: 'add' }
+		| { type: 'grinder'; mode: 'edit'; item: Grinder }
+		| { type: 'brew'; mode: 'add' }
+		| { type: 'brew'; mode: 'edit'; item: BrewSetup };
+
+	let {
+		dialog,
+		brewMethodTypes = [],
+		onSaved,
+		onDeleted,
+		onClose,
+	}: {
+		dialog: DialogType;
+		brewMethodTypes?: BrewMethodType[];
+		onSaved: () => void;
+		onDeleted: () => void;
+		onClose: () => void;
+	} = $props();
+
+	// Person fields
+	let personName = $state('');
+
+	// Grinder fields
+	let gManufacturer = $state('');
+	let gModel = $state('');
+	let gKind = $state<'auto' | 'manual'>('auto');
+	let gRangeMin = $state<number | string>(0);
+	let gRangeMax = $state<number | string>('');
+	let gStep = $state<number | string>(1);
+
+	// Brew setup fields
+	let bManufacturer = $state('');
+	let bModel = $state('');
+	let bMethodType = $state('espresso');
+	let bBasketGrams = $state<number | string>('');
+
+	let saving = $state(false);
+	let confirmDelete = $state(false);
+	let deleteInfo = $state('');
+
+	// Initialize fields from dialog prop
+	$effect(() => {
+		confirmDelete = false;
+		deleteInfo = '';
+		if (dialog.type === 'person') {
+			personName = dialog.mode === 'edit' ? dialog.item.name : '';
+		} else if (dialog.type === 'grinder') {
+			if (dialog.mode === 'edit') {
+				gManufacturer = dialog.item.manufacturer;
+				gModel = dialog.item.model ?? '';
+				gKind = dialog.item.kind as 'auto' | 'manual';
+				gRangeMin = dialog.item.range_min;
+				gRangeMax = dialog.item.range_max ?? '';
+				gStep = dialog.item.step;
+			} else {
+				gManufacturer = ''; gModel = ''; gKind = 'auto';
+				gRangeMin = 0; gRangeMax = ''; gStep = 1;
+			}
+		} else if (dialog.type === 'brew') {
+			if (dialog.mode === 'edit') {
+				bManufacturer = dialog.item.manufacturer;
+				bModel = dialog.item.model ?? '';
+				bMethodType = dialog.item.method_type;
+				bBasketGrams = dialog.item.basket_grams ?? '';
+			} else {
+				bManufacturer = ''; bModel = ''; bMethodType = 'espresso'; bBasketGrams = '';
+			}
+		}
+	});
+
+	const hasBasket = $derived(
+		brewMethodTypes.find(m => m.key === bMethodType)?.has_basket ?? false
+	);
+
+	const canSave = $derived(
+		dialog.type === 'person' ? personName.trim().length > 0 :
+		dialog.type === 'grinder' ? gManufacturer.trim().length > 0 :
+		bManufacturer.trim().length > 0
+	);
+
+	async function save() {
+		if (!canSave) return;
+		saving = true;
+		try {
+			if (dialog.type === 'person') {
+				if (dialog.mode === 'edit') {
+					await api.tasters.update(dialog.item.id, { name: personName.trim() });
+				} else {
+					await api.tasters.create(personName.trim());
+				}
+			} else if (dialog.type === 'grinder') {
+				const data = {
+					manufacturer: gManufacturer.trim(),
+					model: gModel.trim() || undefined,
+					kind: gKind,
+					range_min: Number(gRangeMin) || 0,
+					range_max: gRangeMax !== '' ? Number(gRangeMax) : null,
+					step: Number(gStep) || 1,
+				};
+				if (dialog.mode === 'edit') {
+					await api.grinders.update(dialog.item.id, data);
+				} else {
+					await api.grinders.create(data);
+				}
+			} else if (dialog.type === 'brew') {
+				const data: Record<string, unknown> = {
+					manufacturer: bManufacturer.trim(),
+					model: bModel.trim() || undefined,
+					method_type: bMethodType,
+					basket_grams: hasBasket && bBasketGrams ? Number(bBasketGrams) : null,
+				};
+				if (dialog.mode === 'edit') {
+					await api.brewSetups.update(dialog.item.id, data);
+				} else {
+					await api.brewSetups.create(data as Parameters<typeof api.brewSetups.create>[0]);
+				}
+			}
+			onSaved();
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function startDelete() {
+		if (dialog.mode !== 'edit') return;
+		// Fetch dependents
+		let info = '';
+		if (dialog.type === 'person') {
+			const deps = await api.tasters.dependents(dialog.item.id);
+			if (deps.reviews > 0) info = `${deps.reviews} review(s) will be deleted`;
+		} else if (dialog.type === 'grinder') {
+			const deps = await api.grinders.dependents(dialog.item.id);
+			if (deps.grinder_settings > 0) info = `${deps.grinder_settings} grinder setting(s) will be deleted`;
+		} else if (dialog.type === 'brew') {
+			const deps = await api.brewSetups.dependents(dialog.item.id);
+			const parts = [];
+			if (deps.grinder_settings > 0) parts.push(`${deps.grinder_settings} grinder setting(s)`);
+			if (deps.reviews > 0) parts.push(`${deps.reviews} review(s)`);
+			info = parts.length > 0 ? `${parts.join(' and ')} will be deleted` : '';
+		}
+		deleteInfo = info;
+		confirmDelete = true;
+	}
+
+	async function doDelete() {
+		if (dialog.mode !== 'edit') return;
+		if (dialog.type === 'person') await api.tasters.delete(dialog.item.id);
+		else if (dialog.type === 'grinder') await api.grinders.delete(dialog.item.id);
+		else if (dialog.type === 'brew') await api.brewSetups.delete(dialog.item.id);
+		onDeleted();
+	}
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="fixed inset-0 bg-black/30 z-50 flex items-center justify-center" onclick={onClose}>
+	<div class="bg-card rounded-2xl border border-stone-200 shadow-xl w-full max-w-lg mx-4 p-6 space-y-4"
+		onclick={(e) => e.stopPropagation()}>
+
+		<h3 class="text-xl font-bold text-stone-800" style="font-family: 'DM Serif Display', serif;">
+			{#if dialog.type === 'person'}
+				{dialog.mode === 'edit' ? $t('person.edit') : $t('person.add_new')}
+			{:else if dialog.type === 'grinder'}
+				{dialog.mode === 'edit' ? $t('grinding.edit') : $t('grinding.add')}
+			{:else}
+				{dialog.mode === 'edit' ? $t('brewing.edit') : $t('brewing.add')}
+			{/if}
+		</h3>
+
+		{#if confirmDelete}
+			<div class="space-y-3">
+				<p class="text-sm text-stone-600">{$t('common.delete_confirm')}</p>
+				{#if deleteInfo}
+					<p class="text-sm text-red-500">{deleteInfo}</p>
+				{/if}
+				<div class="flex gap-2 justify-end">
+					<button onclick={() => confirmDelete = false} class="px-4 py-2 text-stone-400 text-sm">{$t('common.cancel')}</button>
+					<button onclick={doDelete} class="px-4 py-2 bg-red-600 text-white rounded-lg text-sm hover:bg-red-700">{$t('detail.delete')}</button>
+				</div>
+			</div>
+		{:else}
+			<!-- Person form -->
+			{#if dialog.type === 'person'}
+				<div>
+					<label for="person-name" class="text-xs text-stone-400 uppercase tracking-wide">{$t('persons.name')}</label>
+					<input id="person-name" type="text" bind:value={personName} placeholder={$t('persons.add_placeholder')}
+						class="w-full mt-1 px-4 py-2.5 rounded-lg border border-stone-200 text-base bg-card-inset
+							focus:outline-none focus:ring-2 focus:ring-amber-400/50"
+						onkeydown={(e) => { if (e.key === 'Enter') save(); }} />
+				</div>
+
+			<!-- Grinder form -->
+			{:else if dialog.type === 'grinder'}
+				{#if dialog.mode === 'add'}
+					<div class="flex gap-3">
+						<button onclick={() => gKind = 'auto'}
+							class="flex-1 flex flex-col items-center gap-1 p-3 rounded-xl border-2 transition-colors
+								{gKind === 'auto' ? 'border-amber-400 bg-amber-50/50' : 'border-stone-100 hover:border-stone-200'}">
+							<img src="/img/grinder-auto.png" alt="" class="w-10 h-10 opacity-70" />
+							<span class="text-xs font-medium {gKind === 'auto' ? 'text-amber-700' : 'text-stone-400'}">Auto</span>
+						</button>
+						<button onclick={() => gKind = 'manual'}
+							class="flex-1 flex flex-col items-center gap-1 p-3 rounded-xl border-2 transition-colors
+								{gKind === 'manual' ? 'border-amber-400 bg-amber-50/50' : 'border-stone-100 hover:border-stone-200'}">
+							<img src="/img/grinder-manual.png" alt="" class="w-10 h-10 opacity-70" />
+							<span class="text-xs font-medium {gKind === 'manual' ? 'text-amber-700' : 'text-stone-400'}">Manual</span>
+						</button>
+					</div>
+				{:else}
+					<div class="flex items-center gap-2">
+						<img src="/img/grinder-{gKind}.png" alt="" class="w-8 h-8 opacity-60" />
+						<span class="text-sm text-stone-500">{gKind === 'manual' ? 'Manual' : 'Auto'}</span>
+					</div>
+				{/if}
+				<div>
+					<label for="g-manufacturer" class="text-xs text-stone-400 uppercase tracking-wide">{$t('grinding.manufacturer')}</label>
+					<input id="g-manufacturer" type="text" bind:value={gManufacturer} placeholder={$t('grinding.manufacturer_placeholder')}
+						class="w-full mt-1 px-4 py-2.5 rounded-lg border border-stone-200 text-base bg-card-inset
+							focus:outline-none focus:ring-2 focus:ring-amber-400/50" />
+				</div>
+				<div>
+					<label for="g-model" class="text-xs text-stone-400 uppercase tracking-wide">{$t('grinding.model')}</label>
+					<input id="g-model" type="text" bind:value={gModel} placeholder={$t('grinding.model_placeholder')}
+						class="w-full mt-1 px-4 py-2.5 rounded-lg border border-stone-200 text-base bg-card-inset
+							focus:outline-none focus:ring-2 focus:ring-amber-400/50" />
+				</div>
+				<div>
+					<label class="text-xs text-stone-400 uppercase tracking-wide">{$t('grinding.range')}</label>
+					<div class="flex items-center gap-2 mt-1">
+						<input type="number" bind:value={gRangeMin} placeholder="0"
+							class="w-20 px-3 py-2 rounded-lg border border-stone-200 text-base bg-card-inset text-center
+								focus:outline-none focus:ring-2 focus:ring-amber-400/50" />
+						<span class="text-stone-400">—</span>
+						<input type="number" bind:value={gRangeMax} placeholder="∞"
+							class="w-20 px-3 py-2 rounded-lg border border-stone-200 text-base bg-card-inset text-center
+								focus:outline-none focus:ring-2 focus:ring-amber-400/50" />
+						<span class="text-xs text-stone-400 mx-1">{$t('grinding.step')}</span>
+						<input type="number" bind:value={gStep} placeholder="1" min="0.1" step="0.1"
+							class="w-16 px-3 py-2 rounded-lg border border-stone-200 text-base bg-card-inset text-center
+								focus:outline-none focus:ring-2 focus:ring-amber-400/50" />
+					</div>
+				</div>
+
+			<!-- Brew setup form -->
+			{:else if dialog.type === 'brew'}
+				{#if dialog.mode === 'add'}
+					<div>
+						<label class="text-xs text-stone-400 uppercase tracking-wide">{$t('brewing.method')}</label>
+						<div class="grid grid-cols-3 gap-2 mt-1">
+							{#each brewMethodTypes as method}
+								<button onclick={() => bMethodType = method.key}
+									class="flex flex-col items-center gap-1 p-2 rounded-xl border-2 transition-colors
+										{bMethodType === method.key ? 'border-amber-400 bg-amber-50/50' : 'border-stone-100 hover:border-stone-200'}">
+									<img src="/img/{method.icon}" alt="" class="w-8 h-8 opacity-70" />
+									<span class="text-[10px] font-medium truncate w-full text-center
+										{bMethodType === method.key ? 'text-amber-700' : 'text-stone-400'}">{$t(`method.${method.key}`)}</span>
+								</button>
+							{/each}
+						</div>
+					</div>
+				{:else}
+					{@const methodIcon = brewMethodTypes.find(m => m.key === bMethodType)?.icon ?? 'method-espresso.png'}
+					<div class="flex items-center gap-2">
+						<img src="/img/{methodIcon}" alt="" class="w-8 h-8 opacity-60" />
+						<span class="text-sm text-stone-500">{$t(`method.${bMethodType}`)}</span>
+					</div>
+				{/if}
+				<div>
+					<label for="b-manufacturer" class="text-xs text-stone-400 uppercase tracking-wide">{$t('brewing.manufacturer')}</label>
+					<input id="b-manufacturer" type="text" bind:value={bManufacturer} placeholder={$t('brewing.manufacturer_placeholder')}
+						class="w-full mt-1 px-4 py-2.5 rounded-lg border border-stone-200 text-base bg-card-inset
+							focus:outline-none focus:ring-2 focus:ring-amber-400/50" />
+				</div>
+				<div>
+					<label for="b-model" class="text-xs text-stone-400 uppercase tracking-wide">{$t('brewing.model')}</label>
+					<input id="b-model" type="text" bind:value={bModel} placeholder={$t('brewing.model_placeholder')}
+						class="w-full mt-1 px-4 py-2.5 rounded-lg border border-stone-200 text-base bg-card-inset
+							focus:outline-none focus:ring-2 focus:ring-amber-400/50" />
+				</div>
+				{#if hasBasket}
+					<div>
+						<label for="b-basket" class="text-xs text-stone-400 uppercase tracking-wide">{$t('brewing.basket')}</label>
+						<input id="b-basket" type="number" bind:value={bBasketGrams} placeholder="18"
+							class="w-32 mt-1 px-4 py-2.5 rounded-lg border border-stone-200 text-base bg-card-inset
+								focus:outline-none focus:ring-2 focus:ring-amber-400/50" />
+					</div>
+				{/if}
+			{/if}
+
+			<!-- Actions -->
+			<div class="flex items-center justify-between pt-2">
+				{#if dialog.mode === 'edit'}
+					<button onclick={startDelete} class="px-3 py-2 text-red-400 hover:text-red-600 text-sm transition-colors">
+						{$t('detail.delete')}
+					</button>
+				{:else}
+					<div></div>
+				{/if}
+				<div class="flex gap-2">
+					<button onclick={onClose} class="px-4 py-2 text-stone-400 text-sm">{$t('common.cancel')}</button>
+					<button onclick={save} disabled={!canSave || saving}
+						class="px-5 py-2 bg-amber-700 text-white rounded-lg text-sm hover:bg-amber-800 disabled:opacity-50">
+						{$t('common.save')}
+					</button>
+				</div>
+			</div>
+		{/if}
+	</div>
+</div>

--- a/frontend/src/lib/components/Icons.svelte
+++ b/frontend/src/lib/components/Icons.svelte
@@ -4,7 +4,7 @@
 
 <script lang="ts">
 	let { icon, size = 24, className = '' }: {
-		icon: 'search' | 'plus' | 'back' | 'link' | 'chevron' | 'users';
+		icon: 'search' | 'plus' | 'back' | 'link' | 'chevron' | 'users' | 'edit';
 		size?: number;
 		className?: string;
 	} = $props();
@@ -28,5 +28,8 @@
 		<circle cx="9" cy="7" r="4" />
 		<path d="M23 21v-2a4 4 0 0 0-3-3.87" />
 		<path d="M16 3.13a4 4 0 0 1 0 7.75" />
+	{:else if icon === 'edit'}
+		<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+		<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
 	{/if}
 </svg>

--- a/frontend/src/lib/components/SwitcherPopover.svelte
+++ b/frontend/src/lib/components/SwitcherPopover.svelte
@@ -13,31 +13,19 @@
 		items,
 		activeId,
 		everyoneLabel = '',
-		addPlaceholder,
 		addLabel,
 		onSelect,
 		onAdd,
-		onRemove,
+		onEdit,
 	}: {
 		items: Item[];
 		activeId: number | null;
 		everyoneLabel?: string;
-		addPlaceholder: string;
 		addLabel: string;
 		onSelect: (id: number | null) => void;
-		onAdd: (name: string) => void;
-		onRemove?: (id: number) => void;
+		onAdd: () => void;
+		onEdit?: (id: number) => void;
 	} = $props();
-
-	let adding = $state(false);
-	let newName = $state('');
-
-	function handleAdd() {
-		if (!newName.trim()) return;
-		onAdd(newName.trim());
-		newName = '';
-		adding = false;
-	}
 </script>
 
 <div class="w-72 bg-card rounded-xl border border-stone-200 shadow-lg z-50 overflow-hidden">
@@ -74,13 +62,13 @@
 							{/if}
 						</div>
 					</button>
-					{#if onRemove}
+					{#if onEdit}
 						<button
-							onclick={(e) => { e.stopPropagation(); onRemove(item.id); }}
-							class="p-2 mr-2 text-stone-300 hover:text-red-400 transition-colors rounded flex-shrink-0"
-							title={$t('detail.delete')}
+							onclick={(e) => { e.stopPropagation(); onEdit(item.id); }}
+							class="p-2 mr-1 text-stone-300 hover:text-amber-600 transition-colors rounded flex-shrink-0"
+							title="Edit"
 						>
-							<img src="/img/knockbox.png" alt="delete" class="w-5 h-5 opacity-50" />
+							<Icons icon="edit" size={14} />
 						</button>
 					{/if}
 				</div>
@@ -89,31 +77,12 @@
 	{/if}
 
 	<div class="border-t border-stone-100">
-		{#if adding}
-			<div class="p-3 flex gap-2">
-				<input
-					type="text"
-					bind:value={newName}
-					placeholder={addPlaceholder}
-					class="flex-1 px-3 py-2 rounded-lg border border-stone-200 text-sm bg-card
-						focus:outline-none focus:ring-2 focus:ring-amber-400/50"
-					onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleAdd(); } if (e.key === 'Escape') { adding = false; newName = ''; } }}
-				/>
-				<button
-					onclick={handleAdd}
-					disabled={!newName.trim()}
-					class="px-3 py-2 bg-amber-700 text-white rounded-lg text-sm hover:bg-amber-800
-						transition-colors disabled:opacity-50"
-				>{addLabel}</button>
-			</div>
-		{:else}
-			<button
-				onclick={(e) => { e.stopPropagation(); adding = true; }}
-				class="w-full text-left px-4 py-3 text-sm text-amber-600 hover:bg-amber-50/50 transition-colors flex items-center gap-3"
-			>
-				<Icons icon="plus" size={14} />
-				{addLabel}
-			</button>
-		{/if}
+		<button
+			onclick={(e) => { e.stopPropagation(); onAdd(); }}
+			class="w-full text-left px-4 py-3 text-sm text-amber-600 hover:bg-amber-50/50 transition-colors flex items-center gap-3"
+		>
+			<Icons icon="plus" size={14} />
+			{addLabel}
+		</button>
 	</div>
 </div>

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -100,10 +100,13 @@ const translations: Record<string, Record<string, string>> = {
 	// Person switcher
 	'person.everyone': { en: 'Everyone', uk: 'Усі' },
 	'person.add_new': { en: 'Add person...', uk: 'Додати персону...' },
+	'persons.name': { en: 'Name', uk: "Ім'я" },
 	'persons.add_placeholder': { en: 'Name...', uk: "Ім'я..." },
 	'persons.add': { en: 'Add', uk: 'Додати' },
+	'person.edit': { en: 'Edit Person', uk: 'Редагувати персону' },
 
 	// Grinding tab (sidebar + detail)
+	'grinding.edit': { en: 'Edit Grinder', uk: 'Редагувати кавомолку' },
 	'grinding.title': { en: 'Grinders', uk: 'Кавомолки' },
 	'grinding.empty': { en: 'No grinders yet', uk: 'Кавомолок ще немає' },
 	'grinding.search': { en: 'Search grinders...', uk: 'Пошук кавомолок...' },
@@ -118,6 +121,8 @@ const translations: Record<string, Record<string, string>> = {
 	'grinding.select': { en: 'Select a grinder', uk: 'Оберіть кавомолку' },
 
 	// Brewing tab (sidebar + detail)
+	'brewing.edit': { en: 'Edit Brew Setup', uk: 'Редагувати налаштування' },
+	'brewing.method': { en: 'Brew method', uk: 'Метод заварювання' },
 	'brewing.title': { en: 'Brew Setups', uk: 'Налаштування заварювання' },
 	'brewing.empty': { en: 'No brew setups yet', uk: 'Налаштувань ще немає' },
 	'brewing.search': { en: 'Search setups...', uk: 'Пошук налаштувань...' },
@@ -155,6 +160,7 @@ const translations: Record<string, Record<string, string>> = {
 	'common.default': { en: 'default', uk: 'за замовч.' },
 	'common.set_default': { en: 'set default', uk: 'за замовч.' },
 	'common.save': { en: 'Save', uk: 'Зберегти' },
+	'common.delete_confirm': { en: 'Are you sure you want to delete this?', uk: 'Ви впевнені, що хочете видалити?' },
 	'common.cancel': { en: 'Cancel', uk: 'Скасувати' },
 };
 


### PR DESCRIPTION
## Summary
- EditDialog modal for add/edit all 3 context types (person, grinder, brew setup)
- Full fields: grinder kind/range/step, brew method type/basket, person name
- Delete with cascade confirmation — shows count of dependent records
- SwitcherPopover now has edit buttons per item and opens dialog for add
- `PUT /tasters/{id}` endpoint for rename
- Dependents endpoints: `/tasters/{id}/dependents`, `/grinders/{id}/dependents`, `/brew-setups/{id}/dependents`

Closes #65

## Test plan
- [x] 92 backend tests, ruff clean, svelte-check 0 errors
- [ ] Add new grinder with all fields via dialog
- [ ] Edit existing grinder — verify fields populate
- [ ] Delete grinder — verify cascade confirmation shows setting count
- [ ] Same for brew setup and person
- [ ] Rename person

🤖 Generated with [Claude Code](https://claude.com/claude-code)