### PR TITLE
UI prototype — cards layout and detail redesign (#74)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ release/
 
 # Original art sources
 art/
+
+# UI screenshots and concepts (local only)
+screenshots/
+concepts/

--- a/backend/app/routers/coffees.py
+++ b/backend/app/routers/coffees.py
@@ -44,32 +44,22 @@ def list_coffees(
 
     coffee_ids = [c.id for c in coffees]
 
-    # Bulk: avg ratings — only for "Everyone" mode, filtered by active brew setup
-    avg_ratings: dict[int, float] = {}
-
     # Resolve active equipment from explicit IDs
     active_grinder = db.query(Grinder).filter(Grinder.id == grinder_id).first() if grinder_id else None
     active_setup = db.query(BrewSetup).filter(BrewSetup.id == brew_setup_id).first() if brew_setup_id else None
 
-    # Bulk: avg ratings for "Everyone" mode, filtered by active brew setup
-    if not taster_id and active_setup:
-        avg_ratings = dict(
-            db.query(Review.coffee_id, func.avg(Review.rating))
-            .filter(Review.coffee_id.in_(coffee_ids), Review.brew_setup_id == active_setup.id)
-            .group_by(Review.coffee_id)
-            .all()
-        )
+    avg_ratings: dict[int, float] = {}
 
-    # Bulk: person ratings for active brew setup (1 query)
-    person_ratings = {}
-    if taster_id and active_setup:
+    # Bulk: person ratings — best rating by this person for each coffee
+    person_ratings: dict[int, int] = {}
+    if taster_id:
         person_ratings = dict(
-            db.query(Review.coffee_id, Review.rating)
+            db.query(Review.coffee_id, func.max(Review.rating))
             .filter(
                 Review.coffee_id.in_(coffee_ids),
                 Review.taster_id == taster_id,
-                Review.brew_setup_id == active_setup.id,
             )
+            .group_by(Review.coffee_id)
             .all()
         )
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -268,6 +268,10 @@ class CoffeeListOut(BaseModel):
     roastery_ref: RoasteryOut | None = None
     roast_level: str | None = None
     image_url: str | None = None
+    score: float | None = None
+    sweetness: int | None = None
+    acidity: int | None = None
+    bitterness: int | None = None
     price: int | None = None
     price_wholesale: int | None = None
     in_stock: bool

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -34,6 +34,16 @@ button, a, input, select, textarea {
 	animation: fadeSlideUp 0.25s ease-out;
 }
 
+/* Staggered card entrance */
+@keyframes cardIn {
+	from { opacity: 0; transform: translateY(8px); }
+	to { opacity: 1; transform: translateY(0); }
+}
+
+.animate-card-grid {
+	animation: cardIn 0.25s ease-out both;
+}
+
 /* Skeleton shimmer */
 @keyframes shimmer {
 	0% { background-position: -400px 0; }
@@ -45,4 +55,60 @@ button, a, input, select, textarea {
 	background-size: 800px 100%;
 	animation: shimmer 1.5s infinite ease-in-out;
 	border-radius: 0.5rem;
+}
+
+/* Mode toggle */
+.mode-toggle {
+	display: inline-flex;
+	background: var(--color-card-inset);
+	border: 1px solid rgba(0, 0, 0, 0.06);
+	border-radius: 0.75rem;
+	padding: 0.2rem;
+	gap: 0.15rem;
+}
+
+.mode-btn {
+	padding: 0.4rem 1rem;
+	border-radius: 0.5rem;
+	font-size: 0.85rem;
+	font-weight: 600;
+	color: #8c7b6b;
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	transition: all 0.2s ease;
+	min-width: 6rem;
+	text-align: center;
+}
+
+.mode-btn:hover {
+	color: #5c4a3a;
+}
+
+.mode-btn.active {
+	background: var(--color-card);
+	color: var(--color-amber-700, #b45309);
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+/* Status bar */
+.status-bar {
+	background: var(--color-card);
+	border-top: 1px solid #e8e0d4;
+	padding: 0.35rem 1.5rem;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	font-size: 0.7rem;
+	color: #8c7b6b;
+	flex-shrink: 0;
+}
+
+.status-bar a {
+	color: #8c7b6b;
+	text-decoration: none;
+}
+
+.status-bar a:hover {
+	color: var(--color-amber-700, #b45309);
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-const BASE_URL = import.meta.env.DEV ? 'http://localhost:8001' : '/api';
+const BASE_URL = '/api';
 
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
 	const res = await fetch(`${BASE_URL}${path}`, {
@@ -132,6 +132,10 @@ export interface CoffeeListItem {
 	origin_ref: Origin | null;
 	roast_level: string | null;
 	image_url: string | null;
+	score: number | null;
+	sweetness: number | null;
+	acidity: number | null;
+	bitterness: number | null;
 	price: number | null;
 	price_wholesale: number | null;
 	in_stock: boolean;

--- a/frontend/src/lib/components/CoffeeCard.svelte
+++ b/frontend/src/lib/components/CoffeeCard.svelte
@@ -1,0 +1,227 @@
+<script lang="ts">
+	import type { CoffeeListItem } from '$lib/api';
+	import type { AppMode } from '$lib/modeStore';
+	import { t } from '$lib/i18n';
+	import { lang } from '$lib/lang';
+	import GrindValue from './GrindValue.svelte';
+
+	let { coffee, mode, onClick }: {
+		coffee: CoffeeListItem;
+		mode: AppMode;
+		onClick: (id: number) => void;
+	} = $props();
+
+	let currentLang = $state('en');
+	lang.subscribe(v => currentLang = v);
+
+	const originName = $derived(
+		coffee.origin_ref
+			? (currentLang === 'uk' ? coffee.origin_ref.name_uk : coffee.origin_ref.name_en)
+			: null
+	);
+
+	const displayPrice = $derived(coffee.price ? `${coffee.price}₴` : null);
+	const ratingDisplay = $derived(coffee.person_rating != null ? coffee.person_rating : null);
+	const avgRatingDisplay = $derived(coffee.avg_rating != null ? Math.round(coffee.avg_rating) : null);
+	const dimmed = $derived(!coffee.in_stock && !coffee.in_store);
+	const descriptorNames = $derived(coffee.roastery_descriptors.slice(0, 5).map(d => d.name));
+	const hasTaste = $derived(coffee.sweetness != null || coffee.acidity != null || coffee.bitterness != null);
+</script>
+
+<button
+	onclick={() => onClick(coffee.id)}
+	class="card text-left w-full {dimmed ? 'opacity-40' : ''}"
+>
+	<!-- COMPACT LAYOUT (mobile/iPad <1024px): name on top, image+info below -->
+	<div class="compact-only">
+		<div class="c-top">
+			<h3 class="c-title">
+				{#if coffee.origin_ref?.flag}<span class="flag">{coffee.origin_ref.flag}</span>{/if}
+				{coffee.name}
+				{#if originName}<span class="c-country">{originName}</span>{/if}
+			</h3>
+			{#if mode === 'my-coffee' && coffee.in_stock}<span class="badge badge-open badge-sm">{$t('card.open')}</span>{/if}
+			{#if mode === 'discover' && coffee.in_store}<span class="badge badge-store badge-sm">{$t('card.inStore')}</span>{/if}
+		</div>
+		<div class="c-bottom">
+			<div class="c-image">
+				{#if coffee.image_url}<img src={coffee.image_url} alt="" class="w-full h-full object-contain" />
+				{:else}<img src="/img/coffee-placeholder.png" alt="" class="w-12 h-12 opacity-30" />{/if}
+			</div>
+			<div class="c-info">
+				<div class="c-mid">
+					{#if hasTaste}
+						<div class="taste-col">
+							{#if coffee.sweetness != null}<div class="taste-item"><span class="taste-lbl ts">{$t('card.sweet')}</span><div class="taste-bg ts"><div class="taste-fill" style="width:{coffee.sweetness*10}%"></div></div><span class="taste-num ts">{coffee.sweetness}</span></div>{/if}
+							{#if coffee.acidity != null}<div class="taste-item"><span class="taste-lbl ts">{$t('card.acid')}</span><div class="taste-bg ts"><div class="taste-fill" style="width:{coffee.acidity*10}%"></div></div><span class="taste-num ts">{coffee.acidity}</span></div>{/if}
+							{#if coffee.bitterness != null}<div class="taste-item"><span class="taste-lbl ts">{$t('card.bitter')}</span><div class="taste-bg ts"><div class="taste-fill" style="width:{coffee.bitterness*10}%"></div></div><span class="taste-num ts">{coffee.bitterness}</span></div>{/if}
+						</div>
+					{/if}
+					<div class="met-col">
+						{#if mode === 'my-coffee'}
+							{#if coffee.default_grind != null}<div class="met ms"><img src="/img/icon-grind.png" alt="" class="met-ico mis" /><GrindValue value={coffee.default_grind} step={coffee.default_grind_step} class="met-val mvs" /></div>{/if}
+							{#if ratingDisplay}<div class="met ms"><img src="/img/icon-rating.png" alt="" class="met-ico mis" /><span class="met-val mvs">{ratingDisplay}</span></div>{/if}
+						{:else}
+							{#if avgRatingDisplay}<div class="met ms"><img src="/img/icon-rating.png" alt="" class="met-ico mis" /><span class="met-val mvs">{avgRatingDisplay}</span></div>{/if}
+							{#if displayPrice}<div class="met ms"><span class="met-price mps">{displayPrice}</span></div>{/if}
+						{/if}
+					</div>
+				</div>
+				{#if descriptorNames.length > 0}
+					<div class="desc-row ds">{#each descriptorNames as n}<span class="desc ds">{n}</span>{/each}</div>
+				{/if}
+			</div>
+		</div>
+	</div>
+
+	<!-- HORIZONTAL LAYOUT (1024px+): image left, info right — scales via CSS -->
+	<div class="horiz-only">
+		<div class="h-image">
+			{#if coffee.image_url}<img src={coffee.image_url} alt="" class="w-full h-full object-contain" />
+			{:else}<img src="/img/coffee-placeholder.png" alt="" class="w-16 h-16 opacity-30" />{/if}
+		</div>
+		<div class="h-body">
+			<div class="h-header">
+				<h3 class="h-title">
+					{#if coffee.origin_ref?.flag}<span class="flag">{coffee.origin_ref.flag}</span>{/if}
+					{coffee.name}
+					{#if originName}<span class="h-country">{originName}</span>{/if}
+				</h3>
+				{#if mode === 'my-coffee' && coffee.in_stock}<span class="badge badge-open">{$t('card.open')}</span>{/if}
+				{#if mode === 'discover' && coffee.in_store}<span class="badge badge-store">{$t('card.inStore')}</span>{/if}
+			</div>
+			<p class="h-roastery">{coffee.roastery_ref.name}</p>
+			<div class="h-mid">
+				{#if hasTaste}
+					<div class="taste-col">
+						{#if coffee.sweetness != null}<div class="taste-item"><span class="taste-lbl">{$t('card.sweet')}</span><div class="taste-bg"><div class="taste-fill" style="width:{coffee.sweetness*10}%"></div></div><span class="taste-num">{coffee.sweetness}</span></div>{/if}
+						{#if coffee.acidity != null}<div class="taste-item"><span class="taste-lbl">{$t('card.acid')}</span><div class="taste-bg"><div class="taste-fill" style="width:{coffee.acidity*10}%"></div></div><span class="taste-num">{coffee.acidity}</span></div>{/if}
+						{#if coffee.bitterness != null}<div class="taste-item"><span class="taste-lbl">{$t('card.bitter')}</span><div class="taste-bg"><div class="taste-fill" style="width:{coffee.bitterness*10}%"></div></div><span class="taste-num">{coffee.bitterness}</span></div>{/if}
+					</div>
+				{/if}
+				<div class="met-col">
+					{#if mode === 'my-coffee'}
+						{#if coffee.default_grind != null}<div class="met"><img src="/img/icon-grind.png" alt="" class="met-ico" /><GrindValue value={coffee.default_grind} step={coffee.default_grind_step} class="met-val" /></div>{/if}
+						{#if ratingDisplay}<div class="met"><img src="/img/icon-rating.png" alt="" class="met-ico" /><span class="met-val">{ratingDisplay}</span></div>{/if}
+					{:else}
+						{#if avgRatingDisplay}<div class="met"><img src="/img/icon-rating.png" alt="" class="met-ico" /><span class="met-val">{avgRatingDisplay}</span></div>{/if}
+						{#if displayPrice}<div class="met"><span class="met-price">{displayPrice}</span></div>{/if}
+					{/if}
+				</div>
+			</div>
+			{#if descriptorNames.length > 0}
+				<div class="desc-row">{#each descriptorNames as n}<span class="desc">{n}</span>{/each}</div>
+			{/if}
+		</div>
+	</div>
+</button>
+
+<style>
+	.card {
+		background: var(--color-card);
+		border-radius: 0.75rem;
+		overflow: hidden;
+		border: 1px solid rgba(0, 0, 0, 0.1);
+		box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
+		transition: transform 0.15s ease, box-shadow 0.15s ease;
+		cursor: pointer;
+	}
+	.card:hover { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08); }
+
+	/* ===== VISIBILITY ===== */
+	.compact-only { display: flex; flex-direction: column; }
+	.horiz-only { display: none; }
+	@media (min-width: 1024px) {
+		.compact-only { display: none; }
+		.horiz-only { display: flex; flex-direction: row; }
+	}
+
+	/* ===== COMPACT (<1024) ===== */
+	.c-top { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; padding: 0.45rem 0.7rem 0.2rem; }
+	.c-title { font-family: 'DM Serif Display', serif; font-size: 0.95rem; line-height: 1.25; color: #2c1810; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
+	.c-country { font-family: 'DM Sans', sans-serif; font-size: 0.72rem; color: #8c7b6b; font-weight: 400; margin-left: 0.2rem; }
+	.c-bottom { display: flex; flex: 1; }
+	.c-image { width: 100px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; padding: 0.3rem; }
+	.c-info { padding: 0.15rem 0.6rem 0.4rem 0.15rem; display: flex; flex-direction: column; justify-content: space-between; flex: 1; min-width: 0; }
+	.c-mid { display: flex; align-items: center; justify-content: space-between; gap: 0.4rem; }
+
+	/* ===== HORIZONTAL (1024+) — scales in 2 tiers ===== */
+
+	/* -- Medium tier: MacBook (1024–1599) -- */
+	.h-image { width: 160px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; padding: 0.5rem; }
+	.h-body { padding: 0.6rem 1rem; display: flex; flex-direction: column; justify-content: space-between; flex: 1; min-width: 0; }
+	.h-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.5rem; }
+	.h-title { font-family: 'DM Serif Display', serif; font-size: 1.1rem; line-height: 1.25; color: #2c1810; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+	.h-country { font-family: 'DM Sans', sans-serif; font-size: 0.8rem; color: #8c7b6b; font-weight: 400; margin-left: 0.2rem; }
+	.h-roastery { font-size: 0.78rem; color: #8c7b6b; margin-top: 0.15rem; }
+	.h-mid { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-top: 0.4rem; }
+
+	/* -- Large tier: Mac Mini (1600+) -- */
+	@media (min-width: 1600px) {
+		.h-image { width: 300px; padding: 1rem; }
+		.h-body { padding: 1.25rem 1.5rem; }
+		.h-title { font-size: 1.5rem; }
+		.h-country { font-size: 0.9rem; margin-left: 0.25rem; }
+		.h-roastery { font-size: 0.9rem; margin-top: 0.25rem; }
+		.h-mid { gap: 1.5rem; margin-top: 0.75rem; }
+	}
+
+	/* ===== SHARED: taste bars ===== */
+	.taste-col { display: flex; flex-direction: column; gap: 0.2rem; flex: 1; min-width: 0; }
+
+	.taste-item { display: flex; align-items: center; gap: 0.3rem; }
+	.taste-lbl { font-size: 0.6rem; color: #8c7b6b; text-transform: uppercase; letter-spacing: 0.03em; width: 2.5rem; flex-shrink: 0; }
+	.taste-lbl.ts { font-size: 0.5rem; width: 1.8rem; }
+	.taste-bg { width: 60px; height: 5px; background: var(--color-card-inset); border-radius: 3px; overflow: hidden; }
+	.taste-bg.ts { width: 40px; height: 3px; border-radius: 2px; }
+	.taste-fill { height: 100%; background: linear-gradient(90deg, #d4a574, #b45309); border-radius: inherit; }
+	.taste-num { font-size: 0.65rem; font-weight: 600; color: #92400e; width: 0.9rem; text-align: right; flex-shrink: 0; }
+	.taste-num.ts { font-size: 0.5rem; width: 0.7rem; }
+
+	@media (min-width: 1600px) {
+		.taste-col { gap: 0.4rem; }
+		.taste-lbl { font-size: 0.65rem; width: 2.8rem; }
+		.taste-bg { width: 80px; height: 6px; }
+		.taste-num { font-size: 0.7rem; width: 1rem; }
+	}
+
+	/* ===== SHARED: metrics ===== */
+	.met-col { display: grid; grid-template-columns: 1fr; gap: 0.2rem; flex-shrink: 0; }
+	.met { display: grid; grid-template-columns: auto 1fr; align-items: center; gap: 0.6rem; background: var(--color-card-inset); padding: 0.15rem 0.7rem; border-radius: 0.4rem; min-width: 5rem; }
+	.met.ms { gap: 0.45rem; padding: 0.12rem 0.55rem; border-radius: 0.35rem; min-width: 4.2rem; }
+	.met-ico { opacity: 0.5; width: 20px; height: 20px; }
+	.met-ico.mis { width: 18px; height: 18px; }
+	:global(.met-val) { font-weight: 700; color: #92400e; font-size: 1.2rem; text-align: right; }
+	:global(.met-val.mvs) { font-size: 1.1rem; }
+	.met-price { font-weight: 700; color: #b45309; font-size: 1.2rem; text-align: right; }
+	.met-price.mps { font-size: 1.1rem; }
+
+	@media (min-width: 1600px) {
+		.met-col { gap: 0.3rem; }
+		.met { gap: 0.75rem; padding: 0.25rem 0.9rem; border-radius: 0.5rem; min-width: 6rem; }
+		.met-ico { width: 28px; height: 28px; }
+		:global(.met-val) { font-size: 1.7rem; }
+		.met-price { font-size: 1.7rem; }
+	}
+
+	/* ===== SHARED: descriptors ===== */
+	.desc-row { display: flex; align-items: center; gap: 0.3rem; flex-wrap: wrap; margin-top: 0.3rem; }
+	.desc-row.ds { margin-top: 0.2rem; }
+	.desc { font-size: 0.7rem; padding: 0.15rem 0.45rem; border-radius: 0.25rem; background: transparent; border: 1px solid #d4c9b8; color: #8c7b6b; white-space: nowrap; }
+	.desc.ds { font-size: 0.6rem; padding: 0.1rem 0.35rem; border-radius: 0.2rem; }
+
+	@media (min-width: 1600px) {
+		.desc-row { gap: 0.35rem; margin-top: auto; padding-top: 0.75rem; }
+		.desc { font-size: 0.75rem; padding: 0.2rem 0.55rem; border-radius: 0.3rem; }
+	}
+
+	/* ===== SHARED: badges & flag ===== */
+	.flag { margin-right: 0.15rem; }
+	@media (min-width: 1600px) { .flag { margin-right: 0.3rem; } }
+
+	.badge { font-size: 0.6rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; padding: 0.12rem 0.4rem; border-radius: 999px; white-space: nowrap; flex-shrink: 0; }
+	.badge-sm { font-size: 0.55rem; padding: 0.1rem 0.35rem; }
+	.badge-open { background: #dcfce7; color: #166534; }
+	.badge-store { background: #dbeafe; color: #1e40af; }
+	@media (min-width: 1600px) { .badge { font-size: 0.65rem; padding: 0.15rem 0.5rem; } }
+</style>

--- a/frontend/src/lib/components/CoffeeCard.svelte
+++ b/frontend/src/lib/components/CoffeeCard.svelte
@@ -22,7 +22,6 @@
 
 	const displayPrice = $derived(coffee.price ? `${coffee.price}₴` : null);
 	const ratingDisplay = $derived(coffee.person_rating != null ? coffee.person_rating : null);
-	const avgRatingDisplay = $derived(coffee.avg_rating != null ? Math.round(coffee.avg_rating) : null);
 	const dimmed = $derived(!coffee.in_stock && !coffee.in_store);
 	const descriptorNames = $derived(coffee.roastery_descriptors.slice(0, 5).map(d => d.name));
 	const hasTaste = $derived(coffee.sweetness != null || coffee.acidity != null || coffee.bitterness != null);
@@ -62,8 +61,8 @@
 							{#if coffee.default_grind != null}<div class="met ms"><img src="/img/icon-grind.png" alt="" class="met-ico mis" /><GrindValue value={coffee.default_grind} step={coffee.default_grind_step} class="met-val mvs" /></div>{/if}
 							{#if ratingDisplay}<div class="met ms"><img src="/img/icon-rating.png" alt="" class="met-ico mis" /><span class="met-val mvs">{ratingDisplay}</span></div>{/if}
 						{:else}
-							{#if avgRatingDisplay}<div class="met ms"><img src="/img/icon-rating.png" alt="" class="met-ico mis" /><span class="met-val mvs">{avgRatingDisplay}</span></div>{/if}
-							{#if displayPrice}<div class="met ms"><span class="met-price mps">{displayPrice}</span></div>{/if}
+							{#if ratingDisplay}<div class="met ms"><img src="/img/icon-rating.png" alt="" class="met-ico mis" /><span class="met-val mvs">{ratingDisplay}</span></div>{/if}
+							{#if displayPrice}<div class="met ms"><span class="met-ico mis met-currency">₴</span><span class="met-val mvs">{coffee.price_wholesale != null ? coffee.price_wholesale : coffee.price}</span></div>{/if}
 						{/if}
 					</div>
 				</div>
@@ -104,8 +103,8 @@
 						{#if coffee.default_grind != null}<div class="met"><img src="/img/icon-grind.png" alt="" class="met-ico" /><GrindValue value={coffee.default_grind} step={coffee.default_grind_step} class="met-val" /></div>{/if}
 						{#if ratingDisplay}<div class="met"><img src="/img/icon-rating.png" alt="" class="met-ico" /><span class="met-val">{ratingDisplay}</span></div>{/if}
 					{:else}
-						{#if avgRatingDisplay}<div class="met"><img src="/img/icon-rating.png" alt="" class="met-ico" /><span class="met-val">{avgRatingDisplay}</span></div>{/if}
-						{#if displayPrice}<div class="met"><span class="met-price">{displayPrice}</span></div>{/if}
+						{#if ratingDisplay}<div class="met"><img src="/img/icon-rating.png" alt="" class="met-ico" /><span class="met-val">{ratingDisplay}</span></div>{/if}
+						{#if displayPrice}<div class="met"><span class="met-ico met-currency">₴</span><span class="met-val">{coffee.price_wholesale != null ? coffee.price_wholesale : coffee.price}</span></div>{/if}
 					{/if}
 				</div>
 			</div>
@@ -191,6 +190,8 @@
 	.met.ms { gap: 0.45rem; padding: 0.12rem 0.55rem; border-radius: 0.35rem; min-width: 4.2rem; }
 	.met-ico { opacity: 0.5; width: 20px; height: 20px; }
 	.met-ico.mis { width: 18px; height: 18px; }
+	.met-currency { width: auto; height: auto; font-size: 1.1rem; font-weight: 700; color: #92400e; opacity: 0.4; }
+	.met-currency.mis { font-size: 0.95rem; }
 	:global(.met-val) { font-weight: 700; color: #92400e; font-size: 1.2rem; text-align: right; }
 	:global(.met-val.mvs) { font-size: 1.1rem; }
 	.met-price { font-weight: 700; color: #b45309; font-size: 1.2rem; text-align: right; }

--- a/frontend/src/lib/components/CoffeeDetail.svelte
+++ b/frontend/src/lib/components/CoffeeDetail.svelte
@@ -278,7 +278,7 @@
 </script>
 
 {#if loading}
-	<div class="max-w-6xl mx-auto p-4 md:p-10 space-y-6 md:space-y-8">
+	<div class="max-w-6xl mx-auto p-3 md:p-5 lg:p-10 space-y-3 md:space-y-4 lg:space-y-6">
 		<!-- Header skeleton -->
 		<div class="flex items-center gap-3">
 			<div class="skeleton w-8 h-8 rounded-full"></div>
@@ -305,7 +305,7 @@
 			</div>
 		</div>
 		<!-- Grinder + Reviews skeleton -->
-		<div class="grid grid-cols-1 xl:grid-cols-2 gap-4 md:gap-6">
+		<div class="detail-bottom-grid">
 			<div class="bg-card rounded-2xl border border-stone-100 shadow-sm p-4 md:p-6 space-y-3">
 				<div class="skeleton h-5 w-32"></div>
 				<div class="skeleton h-4 w-full"></div>
@@ -319,49 +319,42 @@
 		</div>
 	</div>
 {:else if coffee}
-	<div class="max-w-6xl mx-auto p-4 md:p-10 space-y-6 md:space-y-8">
-		<!-- Header -->
-		<div class="flex items-start justify-between">
-			<div class="flex items-center gap-3">
-				<button onclick={onBack}
-					class="p-1.5 text-stone-400 hover:text-stone-600 transition-colors rounded-lg hover:bg-card-inset"
-					title="Back">
-					<Icons icon="back" size={18} />
-				</button>
-				{#if editing}
-					<input type="text" bind:value={editName}
-						class="text-xl md:text-3xl font-bold text-stone-800 bg-transparent border-b-2 border-amber-300 focus:outline-none focus:border-amber-500 px-1 min-w-0"
-						style="font-family: 'DM Serif Display', serif;" />
-				{:else}
-					<h2 class="text-xl md:text-3xl font-bold text-stone-800 break-words" style="font-family: 'DM Serif Display', serif;">
-						{coffee.name}
-					</h2>
-				{/if}
-			</div>
-			<div class="flex items-center gap-2">
+	<div class="detail-page">
+		<!-- Header buttons -->
+		<div class="flex items-center justify-between">
+			<button onclick={onBack}
+				class="flex items-center gap-1 px-2 py-1 md:px-3 md:py-1.5 rounded-lg text-sm font-semibold
+					bg-stone-100 text-stone-600 hover:bg-stone-200 border border-stone-200">
+				<Icons icon="back" size={14} />
+				<span class="hidden md:inline">{$t('common.back')}</span>
+			</button>
+			<div class="flex items-center gap-1.5">
 				{#if !editing && !coffee.roastery_url}
 					<button onclick={startEditing}
-						class="px-3 py-1.5 text-sm text-stone-400 hover:text-amber-600 transition-colors rounded-lg hover:bg-card-inset font-medium">
-						{$t('detail.edit')}
+						class="flex items-center gap-1 px-2 py-1 md:px-3 md:py-1.5 rounded-lg text-sm font-semibold
+							bg-amber-50 text-amber-700 hover:bg-amber-100 border border-amber-200">
+						<Icons icon="edit" size={14} />
+						<span class="hidden md:inline">{$t('detail.edit')}</span>
 					</button>
 				{/if}
-				<button onclick={deleteCoffee} class="p-2 text-stone-400 hover:text-red-500 transition-colors rounded hover:bg-card-inset" title={$t('detail.delete')}>
-					<img src="/img/knockbox.png" alt="delete" class="w-7 h-7 opacity-50" />
+				<button onclick={deleteCoffee}
+					class="flex items-center gap-1 px-2 py-1 md:px-3 md:py-1.5 rounded-lg text-sm font-semibold
+						bg-red-50 text-red-600 hover:bg-red-100 border border-red-200"
+					title={$t('detail.delete')}>
+					<svg viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4"><path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd" /></svg>
+					<span class="hidden md:inline">{$t('detail.delete')}</span>
 				</button>
 			</div>
 		</div>
 
-		<!-- Photo + Details row -->
-		<div class="grid grid-cols-1 {coffee.image_url ? 'xl:grid-cols-[1fr_2fr]' : ''} gap-4 md:gap-6">
-			{#if coffee.image_url}
-				<div class="bg-card rounded-2xl border border-stone-100 shadow-sm animate-card p-6 flex items-center justify-center">
-					<img src={coffee.image_url} alt={coffee.name} class="max-h-64 object-contain" />
-				</div>
-			{/if}
-			<div class="bg-card rounded-2xl border border-stone-100 shadow-sm animate-card overflow-hidden">
-				<div class="p-4 md:p-6 space-y-3 md:space-y-4 min-w-0">
+		<!-- Coffee details card -->
+		<div class="bg-card rounded-xl border border-stone-100 shadow-sm animate-card overflow-hidden">
+			<div class="p-3 md:p-4 lg:p-6 space-y-2 md:space-y-3 lg:space-y-4 min-w-0">
 					{#if editing}
 						<!-- Edit mode -->
+						<input type="text" bind:value={editName}
+							class="text-xl md:text-2xl font-bold text-stone-800 bg-transparent border-b-2 border-amber-300 focus:outline-none focus:border-amber-500 px-1 min-w-0 w-full"
+							style="font-family: 'DM Serif Display', serif;" />
 						<div class="flex flex-wrap items-center justify-between gap-3">
 							<select bind:value={editRoasteryId}
 								class="{inputClass} max-w-[250px]">
@@ -456,148 +449,135 @@
 						</div>
 					{:else}
 						<!-- Display mode -->
-						<!-- Row 1: Roastery + toggles -->
-						<div class="flex flex-wrap items-center justify-between gap-2">
-							<div class="flex items-center gap-2">
-								<img src="/img/header-detail.png" alt="" class="w-12 h-12 opacity-60" />
-								<p class="text-base text-stone-400">{coffee.roastery_ref?.name}</p>
+						<!-- Row 1: Name+country | store+price / quantity -->
+						<div class="detail-header-grid">
+							<div>
+								<h2 class="text-lg md:text-xl lg:text-2xl font-bold text-stone-800 truncate" style="font-family: 'DM Serif Display', serif;">
+									{#if coffee.origin_ref?.flag}<span class="mr-1">{coffee.origin_ref.flag}</span>{/if}
+									{coffee.name}
+								</h2>
+								{#if coffee.origin_ref}
+									<p class="text-xs md:text-sm text-stone-400">{currentLang === 'uk' ? coffee.origin_ref.name_uk : coffee.origin_ref.name_en}</p>
+								{/if}
 							</div>
-							<div class="flex items-center gap-4 md:gap-6">
+							<div class="flex flex-col items-end gap-0.5">
 								<div class="flex items-center gap-2">
-									<button onclick={toggleInStock} aria-label="Toggle in stock"
-										class="relative inline-flex h-5 w-10 items-center rounded-full transition-colors
-											{coffee.in_stock ? 'bg-amber-600' : 'bg-stone-300'}">
-										<span class="inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform
-											{coffee.in_stock ? 'translate-x-5.5' : 'translate-x-0.5'}"></span>
-									</button>
-									<span class="text-xs text-stone-500">{$t('detail.in_stock')}</span>
+									{#if coffee.in_store}
+										<span class="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-blue-50 text-blue-700 border border-blue-100">
+											{#if coffee.roastery_url}
+												<button onclick={refreshCoffee} disabled={refreshing} class="hover:text-blue-900 disabled:opacity-50" title={refreshing ? $t('detail.refreshing') : $t('detail.refresh')}>
+													<svg viewBox="0 0 20 20" fill="currentColor" class="w-3 h-3 {refreshing ? 'animate-spin' : ''}"><path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd" /></svg>
+												</button>
+											{/if}
+											{$t('detail.in_store')}
+										</span>
+									{:else}
+										<span class="text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-stone-100 text-stone-400 border border-stone-200">{$t('detail.sold_out')}</span>
+									{/if}
+									{#if coffee.price != null}
+										<span class="text-base font-bold text-stone-700">{coffee.price_wholesale != null ? coffee.price_wholesale : coffee.price}₴
+											{#if coffee.price_wholesale != null}<span class="text-[10px] text-stone-300 line-through font-normal ml-0.5">{coffee.price}₴</span>{/if}
+										</span>
+									{/if}
 								</div>
-								<div class="flex items-center gap-2">
-									<button onclick={coffee.roastery_url ? undefined : toggleInStore} aria-label="Toggle in store"
-										class="relative inline-flex h-5 w-10 items-center rounded-full transition-colors
-											{coffee.in_store ? 'bg-amber-600' : 'bg-stone-300'}
-											{coffee.roastery_url ? 'opacity-50 cursor-not-allowed' : ''}">
-										<span class="inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform
-											{coffee.in_store ? 'translate-x-5.5' : 'translate-x-0.5'}"></span>
-									</button>
-									<span class="text-xs text-stone-500">{$t('detail.in_store')}</span>
+								<div class="flex items-center gap-1">
+									<button onclick={async () => { if (coffee && coffee.in_stock) { await api.coffees.update(coffeeId, { in_stock: false }); await loadData(); onUpdated(); } }}
+										class="w-5 h-5 rounded flex items-center justify-center text-xs font-bold
+											{coffee.in_stock ? 'bg-stone-100 text-stone-500 hover:bg-stone-200' : 'bg-stone-50 text-stone-300 cursor-not-allowed'}"
+										disabled={!coffee.in_stock}>−</button>
+									<span class="text-base font-bold text-amber-700 w-4 text-center tabular-nums">{coffee.in_stock ? 1 : 0}</span>
+									<button onclick={async () => { if (coffee && !coffee.in_stock) { await api.coffees.update(coffeeId, { in_stock: true }); await loadData(); onUpdated(); } }}
+										class="w-5 h-5 rounded flex items-center justify-center text-xs font-bold
+											bg-amber-50 text-amber-700 hover:bg-amber-100 border border-amber-200">+</button>
+									<span class="text-[10px] text-stone-400 ml-0.5">{$t('detail.in_stock')}</span>
 								</div>
 							</div>
 						</div>
+						{#if refreshError}<p class="text-xs text-red-500">{refreshError}</p>{/if}
 
-						<!-- Row 2: Origin / Process / Roast — always together -->
-						<div class="flex flex-wrap gap-x-8 gap-y-2 text-base">
-							{#if coffee.origin_ref}
-								<div><span class="text-stone-400 text-xs uppercase tracking-wide">{$t('detail.origin')}</span><p class="text-stone-700 font-medium">{coffee.origin_ref.flag ? coffee.origin_ref.flag + ' ' : ''}{currentLang === 'uk' ? coffee.origin_ref.name_uk : coffee.origin_ref.name_en}</p></div>
-							{/if}
-							{#if coffee.process}
-								<div><span class="text-stone-400 text-xs uppercase tracking-wide">{$t('detail.process')}</span><p class="text-stone-700 font-medium">{coffee.process}</p></div>
-							{/if}
-							{#if coffee.roast_level}
-								<div><span class="text-stone-400 text-xs uppercase tracking-wide">{$t('detail.roast')}</span><p class="text-stone-700 font-medium">{coffee.roast_level}</p></div>
-							{/if}
-						</div>
-
-						<!-- Row 3: Score + Price -->
-						{#if coffee.score != null || coffee.price != null}
-							<div class="flex flex-wrap items-end gap-4 md:gap-6">
-								{#if coffee.score != null}
-									<div>
-										<span class="text-stone-400 text-xs uppercase tracking-wide">{$t('detail.score')}</span>
-										<p class="text-2xl font-bold text-amber-700">{coffee.score}</p>
-									</div>
-								{/if}
-								{#if coffee.price != null}
-									<div>
-										<span class="text-stone-400 text-xs uppercase tracking-wide">{$t('detail.price')}</span>
-										<p class="text-2xl font-bold text-stone-700">{coffee.price_wholesale != null ? coffee.price_wholesale : coffee.price}₴
-											{#if coffee.price_wholesale != null}<span class="text-sm text-stone-300 line-through font-normal ml-1">{coffee.price}₴</span>{/if}
-										</p>
-									</div>
-								{/if}
-							</div>
-						{/if}
-
-						<!-- Row 4: Taste profile — boxed grid -->
-						{#if coffee.sweetness != null || coffee.acidity != null || coffee.bitterness != null}
-							<div class="bg-card-inset rounded-xl px-4 py-3">
-								<div class="grid grid-cols-3 gap-3 text-center">
-									{#if coffee.sweetness != null}
-										<div>
-											<p class="text-lg font-bold text-stone-700">{coffee.sweetness}<span class="text-xs text-stone-400 font-normal">/10</span></p>
-											<p class="text-[10px] text-stone-400 uppercase tracking-wide">{$t('detail.sweet')}</p>
-										</div>
-									{/if}
-									{#if coffee.acidity != null}
-										<div>
-											<p class="text-lg font-bold text-stone-700">{coffee.acidity}<span class="text-xs text-stone-400 font-normal">/10</span></p>
-											<p class="text-[10px] text-stone-400 uppercase tracking-wide">{$t('detail.acid')}</p>
-										</div>
-									{/if}
-									{#if coffee.bitterness != null}
-										<div>
-											<p class="text-lg font-bold text-stone-700">{coffee.bitterness}<span class="text-xs text-stone-400 font-normal">/10</span></p>
-											<p class="text-[10px] text-stone-400 uppercase tracking-wide">{$t('detail.bitter')}</p>
-										</div>
-									{/if}
+						<!-- Row 2: [image] | [details+bars] | [stats+comment] -->
+						<div class="detail-3col">
+							<!-- Col 1: Image -->
+							{#if coffee.image_url}
+								<div class="detail-inline-image">
+									<img src={coffee.image_url} alt={coffee.name} class="w-full h-full object-contain" />
 								</div>
-							</div>
-						{/if}
+							{/if}
 
-						<!-- Row 4: Descriptors -->
-						{#if coffee.roastery_descriptors.length > 0}
-							<div class="flex flex-wrap gap-1.5">
-								{#each coffee.roastery_descriptors as desc}
-									<span class="px-2.5 py-1 rounded-full text-sm bg-amber-50 text-amber-700 border border-amber-100">{desc.name}</span>
-								{/each}
-							</div>
-						{/if}
-
-						<!-- Row 5: Roaster comment + notes (full width, below everything) -->
-						{#if roasterCommentText || coffee.notes}
-							<div class="space-y-2">
-								{#if roasterCommentText}
-									<div class="bg-card-inset rounded-xl px-4 py-3">
-										<p class="text-xs text-stone-400 uppercase tracking-wide mb-1">{$t('detail.notes')}</p>
-										<p class="text-sm text-stone-600 italic leading-relaxed">{roasterCommentText}</p>
-									</div>
-								{/if}
-								{#if coffee.notes}
-									<p class="text-sm text-stone-400 italic px-1">{coffee.notes}</p>
-								{/if}
-							</div>
-						{/if}
-
-						<!-- Row 6: Link + refresh + timestamp -->
-						{#if coffee.roastery_url}
-							<div class="flex flex-wrap items-center gap-2 md:gap-3">
-								<a href={coffee.roastery_url} target="_blank" rel="noopener" class="inline-flex items-center gap-1.5 text-xs text-amber-600 hover:text-amber-800">
-									<Icons icon="link" size={12} /> {$t('detail.roastery_link')}
+							<!-- Col 2: Roastery, score, process, roast, taste bars, descriptors -->
+							<div class="space-y-1.5 min-w-0">
+								<a href={coffee.roastery_url ?? '#'} target={coffee.roastery_url ? '_blank' : undefined} rel="noopener"
+									class="text-sm block {coffee.roastery_url ? 'text-amber-600 hover:text-amber-800' : 'text-stone-400 cursor-default'}">
+									{coffee.roastery_ref?.name}
 								</a>
-								<button onclick={refreshCoffee} disabled={refreshing}
-									class="inline-flex items-center gap-1 text-xs text-stone-400 hover:text-amber-600 transition-colors disabled:opacity-50">
-									{refreshing ? $t('detail.refreshing') : $t('detail.refresh')}
-								</button>
-								{#if coffee.fetched_at}
-									<span class="text-[10px] text-stone-300">{$t('detail.fetched_at')} {new Date(coffee.fetched_at).toLocaleDateString()}</span>
+								<div class="flex flex-wrap gap-x-5 gap-y-0.5 text-sm">
+									{#if coffee.score != null}
+										<div><span class="text-stone-400 text-[10px] uppercase tracking-wide">{$t('detail.score')}</span><p class="text-amber-700 font-bold text-sm">{coffee.score}</p></div>
+									{/if}
+									{#if coffee.process}
+										<div><span class="text-stone-400 text-[10px] uppercase tracking-wide">{$t('detail.process')}</span><p class="text-stone-700 font-medium text-sm">{coffee.process}</p></div>
+									{/if}
+									{#if coffee.roast_level}
+										<div><span class="text-stone-400 text-[10px] uppercase tracking-wide">{$t('detail.roast')}</span><p class="text-stone-700 font-medium text-sm">{coffee.roast_level}</p></div>
+									{/if}
+								</div>
+								{#if coffee.sweetness != null || coffee.acidity != null || coffee.bitterness != null}
+									<div class="space-y-1">
+										{#if coffee.sweetness != null}
+											<div class="flex items-center gap-2">
+												<span class="text-[10px] text-stone-400 uppercase tracking-wide w-12">{$t('card.sweet')}</span>
+												<div class="w-20 h-1.5 bg-card-inset rounded-full overflow-hidden"><div class="h-full rounded-full" style="width: {coffee.sweetness * 10}%; background: linear-gradient(90deg, #d4a574, #b45309);"></div></div>
+												<span class="text-xs font-bold text-amber-800 w-4 text-right">{coffee.sweetness}</span>
+											</div>
+										{/if}
+										{#if coffee.acidity != null}
+											<div class="flex items-center gap-2">
+												<span class="text-[10px] text-stone-400 uppercase tracking-wide w-12">{$t('card.acid')}</span>
+												<div class="w-20 h-1.5 bg-card-inset rounded-full overflow-hidden"><div class="h-full rounded-full" style="width: {coffee.acidity * 10}%; background: linear-gradient(90deg, #d4a574, #b45309);"></div></div>
+												<span class="text-xs font-bold text-amber-800 w-4 text-right">{coffee.acidity}</span>
+											</div>
+										{/if}
+										{#if coffee.bitterness != null}
+											<div class="flex items-center gap-2">
+												<span class="text-[10px] text-stone-400 uppercase tracking-wide w-12">{$t('card.bitter')}</span>
+												<div class="w-20 h-1.5 bg-card-inset rounded-full overflow-hidden"><div class="h-full rounded-full" style="width: {coffee.bitterness * 10}%; background: linear-gradient(90deg, #d4a574, #b45309);"></div></div>
+												<span class="text-xs font-bold text-amber-800 w-4 text-right">{coffee.bitterness}</span>
+											</div>
+										{/if}
+									</div>
 								{/if}
 							</div>
-							{#if refreshError}
-								<p class="text-xs text-red-500 mt-1">{refreshError}</p>
-							{/if}
-						{/if}
-						{#if !coffee.roastery_url && coffee.updated_at}
-							<span class="text-[10px] text-stone-300">{$t('detail.updated_at')} {new Date(coffee.updated_at).toLocaleDateString()}</span>
-						{/if}
+
+							<!-- Col 3: Comment + descriptors -->
+							<div class="detail-right-col">
+								{#if roasterCommentText || coffee.notes}
+									<div class="bg-card-inset rounded-lg px-3 py-2 text-left w-full max-w-sm">
+										{#if roasterCommentText}
+											<p class="text-xs text-stone-400 uppercase tracking-wide mb-1">{$t('detail.notes')}</p>
+											<p class="text-sm text-stone-600 italic leading-relaxed">{roasterCommentText}</p>
+										{/if}
+										{#if coffee.notes}
+											<p class="text-xs text-stone-400 italic mt-1">{coffee.notes}</p>
+										{/if}
+									</div>
+								{/if}
+								{#if coffee.roastery_descriptors.length > 0}
+									<div class="flex flex-wrap gap-1 mt-auto pt-1 justify-end">
+										{#each coffee.roastery_descriptors as desc}
+											<span class="px-2 py-0.5 rounded-full text-xs bg-amber-50 text-amber-700 border border-amber-100">{desc.name}</span>
+										{/each}
+									</div>
+								{/if}
+							</div>
+						</div>
 					{/if}
 				</div>
 			</div>
-		</div>
 
 		<!-- Grinder + Reviews row -->
-		<div class="grid grid-cols-1 xl:grid-cols-2 gap-4 md:gap-6">
+		<div class="detail-bottom-grid">
 			<!-- Grinder Settings -->
-			<div class="bg-card rounded-2xl border border-stone-100 shadow-sm animate-card p-4 md:p-6">
+			<div class="bg-card rounded-xl border border-stone-100 shadow-sm animate-card p-3 md:p-4 lg:p-6">
 				<div class="flex items-center justify-between mb-3">
 					<div class="flex items-center gap-2">
 						<img src="/img/burr-icon.png" alt="" class="w-12 h-12 opacity-60" />
@@ -620,12 +600,10 @@
 					</div>
 				{/if}
 				{#each coffee.grinder_settings as setting}
-					<div class="flex items-center gap-2 py-2 border-b border-stone-50 last:border-0">
-						<div class="flex flex-col gap-0.5 flex-1 min-w-0">
-							<span class="text-xs text-stone-500 truncate">{setting.grinder.manufacturer}{setting.grinder.model ? ` ${setting.grinder.model}` : ''}</span>
-							<span class="text-xs text-stone-400 truncate">{setting.brew_setup.manufacturer}{setting.brew_setup.model ? ` ${setting.brew_setup.model}` : ''}</span>
-						</div>
-						<GrindValue value={setting.setting} step={setting.grinder.step} class="text-2xl text-amber-700 flex-shrink-0" />
+					<div class="detail-data-row">
+						<span class="text-sm text-stone-600 truncate">{setting.grinder.manufacturer}{setting.grinder.model ? ` ${setting.grinder.model}` : ''}</span>
+						<span class="text-sm text-stone-400 truncate">{setting.brew_setup.manufacturer}{setting.brew_setup.model ? ` ${setting.brew_setup.model}` : ''}</span>
+						<GrindValue value={setting.setting} step={setting.grinder.step} class="text-2xl text-amber-700" />
 					</div>
 				{/each}
 				{#if showSettingForm}
@@ -662,7 +640,7 @@
 			</div>
 
 			<!-- Reviews -->
-			<div class="bg-card rounded-2xl border border-stone-100 shadow-sm animate-card p-4 md:p-6">
+			<div class="bg-card rounded-xl border border-stone-100 shadow-sm animate-card p-3 md:p-4 lg:p-6">
 				<div class="flex items-center justify-between mb-3">
 					<div class="flex items-center gap-2">
 						<img src="/img/coffee-cup.png" alt="" class="w-12 h-12 opacity-60" />
@@ -702,12 +680,10 @@
 					/>
 				{:else}
 					{#each coffee.reviews as review}
-						<div class="flex items-center gap-2 py-2 border-b border-stone-50 last:border-0">
-							<div class="flex flex-col gap-0.5 flex-1 min-w-0">
-								<span class="text-sm text-stone-600 truncate">{review.taster.name}</span>
-								<span class="text-xs text-stone-400 truncate">{review.brew_setup.manufacturer}{review.brew_setup.model ? ` ${review.brew_setup.model}` : ''}</span>
-							</div>
-							<span class="text-2xl font-bold text-amber-700 tabular-nums flex-shrink-0">{review.rating}</span>
+						<div class="detail-data-row">
+							<span class="text-sm text-stone-600 truncate">{review.taster.name}</span>
+							<span class="text-sm text-stone-400 truncate">{review.brew_setup.manufacturer}{review.brew_setup.model ? ` ${review.brew_setup.model}` : ''}</span>
+							<span class="text-2xl font-bold text-amber-700 tabular-nums">{review.rating}</span>
 						</div>
 					{/each}
 				{/if}
@@ -716,3 +692,118 @@
 		</div>
 	</div>
 {/if}
+
+<style>
+	/* Page container */
+	.detail-page {
+		max-width: 72rem;
+		margin: 0 auto;
+		padding: 0.5rem 0.5rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	@media (min-width: 768px) {
+		.detail-page {
+			padding: 0.5rem 1rem;
+			gap: 0.6rem;
+		}
+	}
+
+	@media (min-width: 1280px) {
+		.detail-page {
+			padding: 1.5rem 2.5rem;
+			gap: 1rem;
+		}
+	}
+
+	/* 3-column layout: image | details | comment */
+	.detail-3col {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+
+	@media (min-width: 768px) {
+		.detail-3col {
+			flex-wrap: nowrap;
+			gap: 0.75rem;
+		}
+	}
+
+	.detail-inline-image {
+		width: 80px;
+		flex-shrink: 0;
+		display: flex;
+		align-items: flex-start;
+		justify-content: center;
+	}
+
+	@media (min-width: 768px) {
+		.detail-inline-image {
+			width: 100px;
+		}
+	}
+
+	.detail-right-col {
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
+	@media (min-width: 768px) {
+		.detail-right-col {
+			width: auto;
+			flex: 1;
+			align-items: flex-end;
+			min-width: 120px;
+		}
+	}
+
+	@media (min-width: 1024px) {
+		.detail-inline-image { width: 130px; }
+	}
+
+	@media (min-width: 1280px) {
+		.detail-3col { gap: 1.5rem; }
+		.detail-inline-image { width: 200px; }
+	}
+
+	.detail-header-grid {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		align-items: start;
+		gap: 0.5rem;
+	}
+
+	.detail-bottom-grid {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 0.5rem;
+	}
+
+	@media (min-width: 768px) {
+		.detail-bottom-grid {
+			grid-template-columns: 1fr 1fr;
+		}
+	}
+
+	@media (min-width: 1280px) {
+		.detail-bottom-grid { gap: 1rem; }
+	}
+
+	.detail-data-row {
+		display: grid;
+		grid-template-columns: 35% 40% auto;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.35rem 0;
+		border-bottom: 1px solid rgba(0,0,0,0.03);
+	}
+
+	.detail-data-row:last-child {
+		border-bottom: none;
+	}
+</style>

--- a/frontend/src/lib/components/ContextSwitcher.svelte
+++ b/frontend/src/lib/components/ContextSwitcher.svelte
@@ -165,7 +165,7 @@
 	<div class="relative">
 		<button
 			onclick={() => toggle('person')}
-			class="w-10 h-10 rounded-xl overflow-hidden border-2 transition-colors hover:border-amber-300
+			class="w-11 h-11 rounded-xl overflow-hidden border-2 transition-colors hover:border-amber-300
 				{openPanel === 'person' ? 'border-amber-400 shadow-sm' : 'border-stone-200'}"
 			title={currentPerson?.name ?? $t('person.everyone')}
 		>
@@ -189,7 +189,7 @@
 	<div class="relative">
 		<button
 			onclick={() => toggle('grinder')}
-			class="w-10 h-10 rounded-xl overflow-hidden border-2 transition-colors hover:border-amber-300
+			class="w-11 h-11 rounded-xl overflow-hidden border-2 transition-colors hover:border-amber-300
 				{openPanel === 'grinder' ? 'border-amber-400 shadow-sm' : 'border-stone-200'}"
 			title={currentGrinder ? `${currentGrinder.manufacturer}${currentGrinder.model ? ` ${currentGrinder.model}` : ''}` : 'Grinder'}
 		>
@@ -213,7 +213,7 @@
 	<div class="relative">
 		<button
 			onclick={() => toggle('brew')}
-			class="w-10 h-10 rounded-xl overflow-hidden border-2 transition-colors hover:border-amber-300
+			class="w-11 h-11 rounded-xl overflow-hidden border-2 transition-colors hover:border-amber-300
 				{openPanel === 'brew' ? 'border-amber-400 shadow-sm' : 'border-stone-200'}"
 			title={currentBrewSetup ? `${currentBrewSetup.manufacturer}${currentBrewSetup.model ? ` ${currentBrewSetup.model}` : ''}` : 'Brew'}
 		>

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -178,6 +178,7 @@ const translations: Record<string, Record<string, string>> = {
 	'empty.discover_hint': { en: 'Add your first coffee to get started', uk: 'Додайте першу каву' },
 
 	// Common
+	'common.back': { en: 'Back', uk: 'Назад' },
 	'common.optional': { en: 'Optional', uk: 'Необов\'язково' },
 	'common.default': { en: 'default', uk: 'за замовч.' },
 	'common.set_default': { en: 'set default', uk: 'за замовч.' },

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -38,6 +38,9 @@ const translations: Record<string, Record<string, string>> = {
 	'detail.sweet': { en: 'Sweet', uk: 'Солодкість' },
 	'detail.acid': { en: 'Acid', uk: 'Кислотність' },
 	'detail.bitter': { en: 'Bitter', uk: 'Гіркота' },
+	'card.sweet': { en: 'SWT', uk: 'СОЛ' },
+	'card.acid': { en: 'ACD', uk: 'КСЛ' },
+	'card.bitter': { en: 'BTR', uk: 'ГРК' },
 	'detail.price': { en: 'Price', uk: 'Ціна' },
 	'detail.price_wholesale': { en: 'Bulk', uk: 'Опт' },
 	'detail.flavor_profile': { en: 'Flavor profile', uk: 'Профіль смаку' },
@@ -155,6 +158,24 @@ const translations: Record<string, Record<string, string>> = {
 	'roastery.select': { en: 'Select a roastery', uk: 'Оберіть ростерню' },
 	'roastery.refresh': { en: 'Refresh all coffees', uk: 'Оновити всю каву' },
 	'roastery.refreshing': { en: 'Refreshing...', uk: 'Оновлення...' },
+
+	// Mode toggle
+	'mode.my_coffee': { en: 'My Coffee', uk: 'Моя кава' },
+	'mode.discover': { en: 'Discover', uk: 'Каталог' },
+
+	// Cards
+	'card.open': { en: 'Open', uk: 'Відкрита' },
+	'card.inStore': { en: 'In Store', uk: 'В магазині' },
+	'card.score': { en: 'Score', uk: 'Оцінка' },
+
+	// Footer
+	'footer.about': { en: 'About', uk: 'Про додаток' },
+
+	// Empty states (new)
+	'empty.my_coffee': { en: 'No coffee at home', uk: 'Вдома немає кави' },
+	'empty.my_coffee_hint': { en: 'Mark some coffee as "at home" or add new', uk: 'Позначте каву як "вдома" або додайте нову' },
+	'empty.discover': { en: 'No coffee in catalog', uk: 'Каталог порожній' },
+	'empty.discover_hint': { en: 'Add your first coffee to get started', uk: 'Додайте першу каву' },
 
 	// Common
 	'common.optional': { en: 'Optional', uk: 'Необов\'язково' },

--- a/frontend/src/lib/modeStore.ts
+++ b/frontend/src/lib/modeStore.ts
@@ -1,0 +1,24 @@
+import { writable } from 'svelte/store';
+
+export type AppMode = 'my-coffee' | 'discover';
+
+const STORAGE_KEY = 'beanbrain-mode';
+
+function createModeStore() {
+	const initial: AppMode =
+		typeof window !== 'undefined'
+			? (localStorage.getItem(STORAGE_KEY) as AppMode) ?? 'my-coffee'
+			: 'my-coffee';
+
+	const store = writable<AppMode>(initial);
+
+	store.subscribe(v => {
+		if (typeof window !== 'undefined') {
+			localStorage.setItem(STORAGE_KEY, v);
+		}
+	});
+
+	return store;
+}
+
+export const appMode = createModeStore();

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -148,7 +148,7 @@
 					</button>
 				</div>
 
-				<div class="controls-right">
+				<div class="controls-right hidden md:block">
 					{#if currentMode === 'discover'}
 						<div class="relative flex items-center">
 							<svg class="absolute left-2.5 w-4 h-4 text-stone-400 pointer-events-none" viewBox="0 0 20 20" fill="currentColor">
@@ -160,12 +160,30 @@
 								placeholder={$t('sidebar.search')}
 								class="pl-8 pr-3 py-2 border border-stone-200 rounded-lg text-sm bg-card-inset
 									focus:outline-none focus:border-amber-400 focus:ring-1 focus:ring-amber-200
-									w-[160px] md:w-[240px] lg:w-[300px]"
+									w-[240px] lg:w-[300px]"
 							/>
 						</div>
 					{/if}
 				</div>
 			</div>
+
+			<!-- Mobile search row (Discover only) -->
+			{#if currentMode === 'discover'}
+				<div class="md:hidden mb-2">
+					<div class="relative flex items-center">
+						<svg class="absolute left-2.5 w-4 h-4 text-stone-400 pointer-events-none" viewBox="0 0 20 20" fill="currentColor">
+							<path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd" />
+						</svg>
+						<input
+							type="text"
+							bind:value={searchQuery}
+							placeholder={$t('sidebar.search')}
+							class="w-full pl-8 pr-3 py-2 border border-stone-200 rounded-lg text-sm bg-card-inset
+								focus:outline-none focus:border-amber-400 focus:ring-1 focus:ring-amber-200"
+						/>
+					</div>
+				</div>
+			{/if}
 
 			<!-- Cards grid -->
 			{#if filteredCoffees.length === 0}
@@ -241,6 +259,8 @@
 		background: var(--color-card);
 		border-bottom: 1px solid rgba(0, 0, 0, 0.08);
 		flex-shrink: 0;
+		position: relative;
+		z-index: 20;
 	}
 
 	.app-shell {
@@ -381,9 +401,8 @@
 		color: var(--color-amber-700, #b45309);
 	}
 
-	/* Hide grinder + brew setup in discover mode */
-	.discover-context :global(.context-switcher > div:nth-child(2)),
-	.discover-context :global(.context-switcher > div:nth-child(3)) {
+	/* Hide only grinder in discover mode (keep person + brew for rating) */
+	.discover-context :global(.context-switcher > div:nth-child(2)) {
 		display: none;
 	}
 </style>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,215 +1,389 @@
 <script lang="ts">
-	import { api, type CoffeeListItem, type Roastery } from '$lib/api';
+	import { api, type CoffeeListItem } from '$lib/api';
 	import { lang, type Lang } from '$lib/lang';
 	import { activePerson } from '$lib/personStore';
 	import { activeGrinder, activeBrewSetup } from '$lib/contextStore';
+	import { appMode, type AppMode } from '$lib/modeStore';
 	import { t } from '$lib/i18n';
-	import CoffeeSidebar from '$lib/components/CoffeeSidebar.svelte';
+	import ContextSwitcher from '$lib/components/ContextSwitcher.svelte';
 	import CoffeeDetail from '$lib/components/CoffeeDetail.svelte';
 	import AddCoffeePanel from '$lib/components/AddCoffeePanel.svelte';
-	import RoasterySidebar from '$lib/components/RoasterySidebar.svelte';
-	import RoasteryDetail from '$lib/components/RoasteryDetail.svelte';
-	import AddRoasteryPanel from '$lib/components/AddRoasteryPanel.svelte';
-	import ContextSwitcher from '$lib/components/ContextSwitcher.svelte';
+	import CoffeeCard from '$lib/components/CoffeeCard.svelte';
 	import EmptyState from '$lib/components/EmptyState.svelte';
 
-	type Tab = 'coffee' | 'roasteries';
-	type CoffeePanel = { type: 'empty' } | { type: 'detail'; id: number } | { type: 'new' };
-	type RoasteryPanel = { type: 'empty' } | { type: 'detail'; id: number } | { type: 'new' };
+	type View = { type: 'grid' } | { type: 'detail'; id: number } | { type: 'new' };
 
-	let activeTab = $state<Tab>('coffee');
-	let coffees = $state<CoffeeListItem[]>([]);
-	let coffeePanel = $state<CoffeePanel>({ type: 'empty' });
-
-	let roasteriesList = $state<Roastery[]>([]);
-	let roasteryPanel = $state<RoasteryPanel>({ type: 'empty' });
+	let allCoffees = $state<CoffeeListItem[]>([]);
+	let view = $state<View>({ type: 'grid' });
+	let searchQuery = $state('');
 
 	let currentLang = $state<Lang>('en');
+	let currentMode = $state<AppMode>('my-coffee');
 	let currentPersonId = $state<number | null>(null);
 	let currentGrinderId = $state<number | null>(null);
 	let currentBrewSetupId = $state<number | null>(null);
 
 	lang.subscribe(v => currentLang = v);
+	appMode.subscribe(v => currentMode = v);
 	activePerson.subscribe(v => currentPersonId = v);
 	activeGrinder.subscribe(v => currentGrinderId = v);
 	activeBrewSetup.subscribe(v => currentBrewSetupId = v);
 
-	const tabDefs: { id: Tab; key: string; img: string }[] = [
-		{ id: 'coffee', key: 'tab.coffee', img: '/img/tab-coffee.png' },
-		{ id: 'roasteries', key: 'tab.roasteries', img: '/img/tab-roastery.png' },
-	];
-
 	async function loadCoffees() {
-		coffees = await api.coffees.list({
+		allCoffees = await api.coffees.list({
 			tasterId: currentPersonId,
 			grinderId: currentGrinderId,
 			brewSetupId: currentBrewSetupId,
 		});
 	}
 
-	async function loadRoasteries() {
-		roasteriesList = await api.roasteries.list();
-	}
-
 	$effect(() => { currentPersonId; currentGrinderId; currentBrewSetupId; loadCoffees(); });
-	$effect(() => { if (activeTab === 'roasteries') loadRoasteries(); });
+
+	const filteredCoffees = $derived.by(() => {
+		let list = allCoffees;
+
+		if (currentMode === 'my-coffee') {
+			list = list.filter(c => c.in_stock);
+			list = [...list].sort((a, b) => a.name.localeCompare(b.name));
+		} else {
+			if (searchQuery.trim()) {
+				const q = searchQuery.toLowerCase();
+				list = list.filter(c =>
+					c.name.toLowerCase().includes(q) ||
+					c.roastery_ref.name.toLowerCase().includes(q) ||
+					(c.origin_ref?.name_en.toLowerCase().includes(q)) ||
+					(c.origin_ref?.name_uk.toLowerCase().includes(q)) ||
+					c.roastery_descriptors.some(d => d.name.toLowerCase().includes(q))
+				);
+			}
+			list = [...list].sort((a, b) => b.created_at.localeCompare(a.created_at));
+		}
+
+		return list;
+	});
 
 	function selectCoffee(id: number) {
-		coffeePanel = { type: 'detail', id };
+		view = { type: 'detail', id };
 	}
 
 	async function onCoffeeCreated(id: number) {
 		await loadCoffees();
-		coffeePanel = { type: 'detail', id };
+		view = { type: 'detail', id };
 	}
 
 	async function onCoffeeDeleted() {
 		await loadCoffees();
-		coffeePanel = { type: 'empty' };
+		view = { type: 'grid' };
 	}
 
-	// Roastery handlers
-	function selectRoastery(id: number) {
-		roasteryPanel = { type: 'detail', id };
-	}
-
-	async function onRoasteryCreated(id: number) {
-		await loadRoasteries();
-		roasteryPanel = { type: 'detail', id };
-	}
-
-	async function onRoasteryUpdated() {
-		await loadRoasteries();
-		if (roasteryPanel.type === 'detail') {
-			roasteryPanel = { ...roasteryPanel };
-		}
-	}
-
-	async function onRoasteryDeleted() {
-		await loadRoasteries();
-		roasteryPanel = { type: 'empty' };
+	function backToGrid() {
+		view = { type: 'grid' };
 	}
 
 	function toggleLang() {
 		lang.set(currentLang === 'en' ? 'uk' : 'en');
 	}
 
+	function setMode(mode: AppMode) {
+		appMode.set(mode);
+		view = { type: 'grid' };
+	}
+
 	const appVersion = __APP_VERSION__;
 
-	const selectedCoffeeId = $derived(coffeePanel.type === 'detail' ? coffeePanel.id : null);
-	const selectedRoasteryId = $derived(roasteryPanel.type === 'detail' ? roasteryPanel.id : null);
-	const selectedRoastery = $derived(
-		selectedRoasteryId != null ? roasteriesList.find(r => r.id === selectedRoasteryId) ?? null : null
-	);
-
-	// Responsive: track if we're in mobile mode
 	let innerWidth = $state(0);
 	const isMobile = $derived(innerWidth < 768);
-
-	// On mobile, detail panel is shown = sidebar hidden
-	const showingDetail = $derived(
-		(activeTab === 'coffee' && coffeePanel.type !== 'empty') ||
-		(activeTab === 'roasteries' && roasteryPanel.type !== 'empty')
-	);
-
-	function mobileBack() {
-		if (activeTab === 'coffee') coffeePanel = { type: 'empty' };
-		else if (activeTab === 'roasteries') roasteryPanel = { type: 'empty' };
-	}
 </script>
 
 <svelte:window bind:innerWidth />
 
-<div class="flex flex-col h-screen overflow-hidden text-base">
+<div class="app-shell">
 	<!-- Top bar -->
-	<header class="bg-card border-b border-stone-200 flex-shrink-0">
-		<div class="flex items-center justify-between px-2 xl:px-5">
-			<div class="flex items-center gap-2 xl:gap-8">
-				<!-- Logo: icon only below xl -->
-				<img src="/img/logo-text.png" alt="BeanBrain" class="self-stretch py-1 object-contain max-w-[80px] md:max-w-[120px] xl:max-w-[180px]" />
-
-				<nav class="flex">
-					{#each tabDefs as tab}
-						<button
-							onclick={() => activeTab = tab.id}
-							class="flex items-center gap-1 xl:gap-3 px-2 md:px-4 xl:px-7 py-3 xl:py-5 text-lg font-medium transition-colors
-								border-b-2 -mb-px
-								{activeTab === tab.id
-									? 'border-amber-600 text-amber-700'
-									: 'border-transparent text-stone-400 hover:text-stone-600'}"
-						>
-							<img src={tab.img} alt="" class="w-7 h-7 md:w-9 md:h-9 xl:w-12 xl:h-12 {activeTab === tab.id ? 'opacity-90' : 'opacity-40'}" />
-							<span class="hidden xl:inline">{$t(tab.key)}</span>
-						</button>
-					{/each}
-				</nav>
-			</div>
-
-			<div class="flex items-center gap-2 xl:gap-3">
-				<span class="hidden md:inline text-xs text-stone-300 font-mono">v{appVersion}</span>
-				<ContextSwitcher onChange={loadCoffees} />
-				<button
-					onclick={toggleLang}
-					class="flex items-center gap-1.5 px-2 xl:px-3 py-2 rounded-lg text-sm font-medium
-						bg-card-inset hover:bg-parchment transition-colors text-stone-500"
-					title="Switch language"
-				>
-					{#if currentLang === 'en'}
-						<span class="text-lg leading-none">🇬🇧</span>
-						<span class="hidden xl:inline">EN</span>
-					{:else}
-						<span class="text-lg leading-none">🇺🇦</span>
-						<span class="hidden xl:inline">UA</span>
-					{/if}
-				</button>
+	<header class="topbar">
+		<div class="topbar-inner">
+			<img src="/img/logo-text.png" alt="BeanBrain" class="topbar-logo" />
+			<div class="flex items-center gap-2">
+				{#if currentMode === 'my-coffee'}
+					<ContextSwitcher onChange={loadCoffees} />
+				{:else}
+					<div class="discover-context">
+						<ContextSwitcher onChange={loadCoffees} />
+					</div>
+				{/if}
 			</div>
 		</div>
 	</header>
 
-	<!-- Content -->
-	<div class="flex flex-1 overflow-hidden">
-		{#if activeTab === 'coffee'}
-			{#if !isMobile || !showingDetail}
-				<CoffeeSidebar
-					{coffees}
-					selectedId={selectedCoffeeId}
-					onSelect={selectCoffee}
-					onAdd={() => coffeePanel = { type: 'new' }}
-					onRefresh={loadCoffees}
-				/>
-			{/if}
-			{#if !isMobile || showingDetail}
-				<div class="flex-1 overflow-y-auto bg-parchment" style="background-image: url('/img/bg-pattern.png'); background-repeat: repeat;">
-					{#if coffeePanel.type === 'empty'}
-						<EmptyState img="choose-coffee.png" title={$t('empty.title')} subtitle={$t('empty.subtitle')} />
-					{:else if coffeePanel.type === 'detail'}
-						<CoffeeDetail coffeeId={coffeePanel.id} onDeleted={onCoffeeDeleted} onUpdated={loadCoffees} onBack={isMobile ? mobileBack : () => coffeePanel = { type: 'empty' }} />
-					{:else if coffeePanel.type === 'new'}
-						<AddCoffeePanel onCreated={onCoffeeCreated} onCancel={isMobile ? mobileBack : () => coffeePanel = { type: 'empty' }} />
-					{/if}
-				</div>
-			{/if}
+	{#if view.type === 'grid'}
+		<main class="flex-1 overflow-y-auto bg-parchment px-2 md:px-3 py-2 md:py-3"
+			style="background-image: url('/img/bg-pattern.png'); background-repeat: repeat;">
 
-		{:else if activeTab === 'roasteries'}
-			{#if !isMobile || !showingDetail}
-				<RoasterySidebar
-					roasteries={roasteriesList}
-					selectedId={selectedRoasteryId}
-					onSelect={selectRoastery}
-					onAdd={() => roasteryPanel = { type: 'new' }}
-				/>
-			{/if}
-			{#if !isMobile || showingDetail}
-				<div class="flex-1 overflow-y-auto bg-parchment" style="background-image: url('/img/bg-pattern.png'); background-repeat: repeat;">
-					{#if roasteryPanel.type === 'empty'}
-						<EmptyState img="many-roasteries.png" title={$t('roastery.select')} />
-					{:else if roasteryPanel.type === 'detail' && selectedRoastery}
-						<RoasteryDetail roastery={selectedRoastery} onUpdated={onRoasteryUpdated} onDeleted={onRoasteryDeleted} onBack={isMobile ? mobileBack : () => roasteryPanel = { type: 'empty' }} />
-					{:else if roasteryPanel.type === 'new'}
-						<AddRoasteryPanel onCreated={onRoasteryCreated} onCancel={isMobile ? mobileBack : () => roasteryPanel = { type: 'empty' }} />
+			<!-- Controls row -->
+			<div class="controls-row">
+				<div class="controls-left">
+					<button
+						onclick={() => view = { type: 'new' }}
+						class="add-btn"
+						title={$t('add.title')}
+					>
+						<svg viewBox="0 0 20 20" fill="currentColor" class="w-5 h-5">
+							<path d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" />
+						</svg>
+						<span class="hidden md:inline">{$t('add.title')}</span>
+					</button>
+				</div>
+
+				<div class="mode-toggle">
+					<button
+						class="mode-btn {currentMode === 'my-coffee' ? 'active' : ''}"
+						onclick={() => setMode('my-coffee')}
+					>
+						{$t('mode.my_coffee')}
+					</button>
+					<button
+						class="mode-btn {currentMode === 'discover' ? 'active' : ''}"
+						onclick={() => setMode('discover')}
+					>
+						{$t('mode.discover')}
+					</button>
+				</div>
+
+				<div class="controls-right">
+					{#if currentMode === 'discover'}
+						<div class="relative flex items-center">
+							<svg class="absolute left-2.5 w-4 h-4 text-stone-400 pointer-events-none" viewBox="0 0 20 20" fill="currentColor">
+								<path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd" />
+							</svg>
+							<input
+								type="text"
+								bind:value={searchQuery}
+								placeholder={$t('sidebar.search')}
+								class="pl-8 pr-3 py-2 border border-stone-200 rounded-lg text-sm bg-card-inset
+									focus:outline-none focus:border-amber-400 focus:ring-1 focus:ring-amber-200
+									w-[160px] md:w-[240px] lg:w-[300px]"
+							/>
+						</div>
 					{/if}
 				</div>
+			</div>
+
+			<!-- Cards grid -->
+			{#if filteredCoffees.length === 0}
+				<div class="flex items-center justify-center" style="min-height: 60vh;">
+					<EmptyState
+						img={currentMode === 'my-coffee' ? 'empty-shelf.png' : 'choose-coffee.png'}
+						title={$t(currentMode === 'my-coffee' ? 'empty.my_coffee' : 'empty.discover')}
+						subtitle={$t(currentMode === 'my-coffee' ? 'empty.my_coffee_hint' : 'empty.discover_hint')}
+					/>
+				</div>
+			{:else}
+				<div class="card-grid">
+					{#each filteredCoffees as coffee, i (coffee.id)}
+						<div class="animate-card-grid" style="animation-delay: {Math.min(i * 30, 300)}ms">
+							<CoffeeCard {coffee} mode={currentMode} onClick={selectCoffee} />
+						</div>
+					{/each}
+				</div>
 			{/if}
-		{/if}
+		</main>
+
+	{:else if view.type === 'detail'}
+		<main class="flex-1 overflow-y-auto bg-parchment" style="background-image: url('/img/bg-pattern.png'); background-repeat: repeat;">
+			<CoffeeDetail
+				coffeeId={view.id}
+				onDeleted={onCoffeeDeleted}
+				onUpdated={loadCoffees}
+				onBack={backToGrid}
+			/>
+		</main>
+
+	{:else if view.type === 'new'}
+		<main class="flex-1 overflow-y-auto bg-parchment" style="background-image: url('/img/bg-pattern.png'); background-repeat: repeat;">
+			<AddCoffeePanel
+				onCreated={onCoffeeCreated}
+				onCancel={backToGrid}
+			/>
+		</main>
+	{/if}
+
+	<!-- Status bar -->
+	<div class="statusbar">
+		<div class="flex items-center gap-3">
+			<a href="https://github.com/birrgrrim/beanbrain" target="_blank" rel="noopener" title="GitHub">
+				<svg viewBox="0 0 24 24" fill="currentColor" class="w-4 h-4">
+					<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+				</svg>
+			</a>
+		</div>
+		<div class="flex items-center gap-4">
+			<button
+				onclick={toggleLang}
+				class="flex items-center gap-1.5 hover:text-amber-700"
+				style="color: inherit;"
+			>
+				{#if currentLang === 'en'}
+					<span>🇬🇧</span> EN
+				{:else}
+					<span>🇺🇦</span> UA
+				{/if}
+			</button>
+			<span class="text-stone-300">·</span>
+			<button class="hover:text-amber-700" style="color: inherit;">
+				{$t('footer.about')}
+			</button>
+		</div>
 	</div>
 </div>
+
+<style>
+	/* Top bar — proportional */
+	.topbar {
+		background: var(--color-card);
+		border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+		flex-shrink: 0;
+	}
+
+	.app-shell {
+		display: flex;
+		flex-direction: column;
+		height: 100vh;
+		height: 100dvh;
+		overflow: hidden;
+		font-size: 1rem;
+	}
+
+	.topbar-inner {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 0.1rem 0.75rem;
+	}
+
+	@media (min-width: 768px) {
+		.topbar-inner {
+			padding: 0.1rem 1rem;
+		}
+	}
+
+	.topbar-logo {
+		object-fit: contain;
+		height: 42px;
+	}
+
+	@media (min-width: 768px) {
+		.topbar-logo {
+			height: 48px;
+		}
+	}
+
+	/* Controls row */
+	.controls-row {
+		display: grid;
+		grid-template-columns: 1fr auto 1fr;
+		align-items: center;
+		gap: 0.75rem;
+		margin-bottom: 0.75rem;
+	}
+
+	.controls-left {
+		justify-self: start;
+	}
+
+	.controls-right {
+		justify-self: end;
+	}
+
+	@media (min-width: 768px) {
+		.controls-row {
+			margin-bottom: 1rem;
+		}
+	}
+
+	.add-btn {
+		display: flex;
+		align-items: center;
+		gap: 0.3rem;
+		padding: 0.4rem 0.75rem;
+		border-radius: 0.5rem;
+		font-size: 0.85rem;
+		font-weight: 600;
+		background: var(--color-amber-600, #d97706);
+		color: white;
+		border: none;
+		cursor: pointer;
+	}
+
+	@media (min-width: 768px) {
+		.add-btn {
+			padding: 0.5rem 1rem;
+			font-size: 0.9rem;
+		}
+	}
+
+	.add-btn:hover {
+		background: var(--color-amber-700, #b45309);
+	}
+
+	/* Card grid — auto-fill, 3 columns on ~1900px+ */
+	.card-grid {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 0.5rem;
+	}
+
+	@media (min-width: 640px) {
+		.card-grid {
+			grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));
+			gap: 0.6rem;
+		}
+	}
+
+	@media (min-width: 1024px) {
+		.card-grid {
+			grid-template-columns: repeat(auto-fill, minmax(480px, 1fr));
+			gap: 0.6rem;
+		}
+	}
+
+	@media (min-width: 1600px) {
+		.card-grid {
+			grid-template-columns: repeat(auto-fill, minmax(700px, 1fr));
+			gap: 0.75rem;
+		}
+	}
+
+	/* Status bar — proportional */
+	.statusbar {
+		background: var(--color-card);
+		border-top: 1px solid rgba(0, 0, 0, 0.08);
+		padding: 0.4rem 1rem;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		font-size: 0.75rem;
+		color: #8c7b6b;
+		flex-shrink: 0;
+	}
+
+	@media (min-width: 768px) {
+		.statusbar {
+			padding: 0.5rem 1.5rem;
+			font-size: 0.8rem;
+		}
+	}
+
+	.statusbar a {
+		color: #8c7b6b;
+		text-decoration: none;
+	}
+
+	.statusbar a:hover {
+		color: var(--color-amber-700, #b45309);
+	}
+
+	/* Hide grinder + brew setup in discover mode */
+	.discover-context :global(.context-switcher > div:nth-child(2)),
+	.discover-context :global(.context-switcher > div:nth-child(3)) {
+		display: none;
+	}
+</style>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,4 +8,12 @@ export default defineConfig({
 	define: {
 		__APP_VERSION__: JSON.stringify(pkg.version),
 	},
+	server: {
+		proxy: {
+			'/api': {
+				target: 'http://localhost:8001',
+				rewrite: (path) => path.replace(/^\/api/, ''),
+			},
+		},
+	},
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
 				target: 'http://localhost:8001',
 				rewrite: (path) => path.replace(/^\/api/, ''),
 			},
+			'/avatars': {
+				target: 'http://localhost:8001',
+			},
 		},
 	},
 });


### PR DESCRIPTION
## Summary
- Replace sidebar+detail layout with responsive card grid and two modes ("My Coffee" / "Discover")
- Three responsive card tiers: compact vertical (mobile/iPad), horizontal medium (MacBook), horizontal large (Mac Mini)
- Redesigned coffee detail page: 3-column layout (image | details+taste bars | comment+descriptors), fits all devices without scrolling
- Mode toggle, status bar, API proxy for cross-device dev testing
- Taste profile (sweet/acid/bitter) fields added to coffee list endpoint
- Rating shown as person's best rating across brew setups, displayed in both modes
- Price styled as metric pill matching grind/rating style

## Devices tested
- Mac Mini (2560x1440 external display)
- MacBook Air (Retina)
- iPad
- iPhone

## Related issues
- Closes #74
- New issues created for remaining UI work: #81 (add coffee), #82 (edit/review/grind), #83 (equipment/roastery), #84 (about/polish)

## Test plan
- [ ] Verify My Coffee cards on all devices
- [ ] Verify Discover cards with search on all devices  
- [ ] Verify coffee detail view on all devices
- [ ] Test mode switching persists in localStorage
- [ ] Test context switcher popovers render above cards
- [ ] Test Ukrainian language doesn't overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)